### PR TITLE
fix: prevent context overflow when clustering returns 0 modules

### DIFF
--- a/codewiki/src/be/agent_orchestrator.py
+++ b/codewiki/src/be/agent_orchestrator.py
@@ -65,17 +65,19 @@ class AgentOrchestrator:
     def create_agent(self, module_name: str, components: Dict[str, Any], 
                     core_component_ids: List[str]) -> Agent:
         """Create an appropriate agent based on module complexity."""
+        # FLAMINGO_PATCH: Added retries=3 to fix "Tool exceeded max retries count of 1" errors
         if is_complex_module(components, core_component_ids):
             return Agent(
                 self.fallback_models,
                 name=module_name,
                 deps_type=CodeWikiDeps,
                 tools=[
-                    read_code_components_tool, 
-                    str_replace_editor_tool, 
+                    read_code_components_tool,
+                    str_replace_editor_tool,
                     generate_sub_module_documentation_tool
                 ],
                 system_prompt=SYSTEM_PROMPT.format(module_name=module_name),
+                retries=3,
             )
         else:
             return Agent(
@@ -84,6 +86,7 @@ class AgentOrchestrator:
                 deps_type=CodeWikiDeps,
                 tools=[read_code_components_tool, str_replace_editor_tool],
                 system_prompt=LEAF_SYSTEM_PROMPT.format(module_name=module_name),
+                retries=3,
             )
     
     async def process_module(self, module_name: str, components: Dict[str, Node], 

--- a/codewiki/src/be/agent_tools/generate_sub_module_documentations.py
+++ b/codewiki/src/be/agent_tools/generate_sub_module_documentations.py
@@ -47,6 +47,7 @@ async def generate_sub_module_documentation(
 
         num_tokens = count_tokens(format_potential_core_components(core_component_ids, ctx.deps.components)[-1])
         
+        # FLAMINGO_PATCH: Added retries=3 to fix "Tool exceeded max retries count of 1" errors
         if is_complex_module(ctx.deps.components, core_component_ids) and ctx.deps.current_depth < ctx.deps.max_depth and num_tokens >= MAX_TOKEN_PER_LEAF_MODULE:
             sub_agent = Agent(
                 model=fallback_models,
@@ -54,6 +55,7 @@ async def generate_sub_module_documentation(
                 deps_type=CodeWikiDeps,
                 system_prompt=SYSTEM_PROMPT.format(module_name=sub_module_name),
                 tools=[read_code_components_tool, str_replace_editor_tool, generate_sub_module_documentation_tool],
+                retries=3,
             )
         else:
             sub_agent = Agent(
@@ -62,6 +64,7 @@ async def generate_sub_module_documentation(
                 deps_type=CodeWikiDeps,
                 system_prompt=LEAF_SYSTEM_PROMPT.format(module_name=sub_module_name),
                 tools=[read_code_components_tool, str_replace_editor_tool],
+                retries=3,
             )
 
         deps.current_module_name = sub_module_name

--- a/codewiki/src/be/documentation_generator.py
+++ b/codewiki/src/be/documentation_generator.py
@@ -1,3 +1,11 @@
+"""
+Documentation Generator Module
+
+SYNTHETIC_MODULE_PATCH: Patched by flamingo-stack to prevent context overflow
+
+This module contains the DocumentationGenerator class which orchestrates the
+documentation generation process for a given repository.
+"""
 import logging
 import os
 import json
@@ -267,6 +275,29 @@ class DocumentationGenerator:
             else:
                 logger.debug(f"Module tree not found at {module_tree_path}, clustering modules")
                 module_tree = cluster_modules(leaf_nodes, components, self.config)
+
+                # === SYNTHETIC_MODULE_PATCH: Prevent context overflow ===
+                # If clustering returned 0 modules but we have leaf nodes, create synthetic modules
+                # This prevents the "whole repo" fallback that exceeds API context limits
+                # See: https://github.com/flamingo-stack/CodeWiki - forked with this fix
+                if len(module_tree) == 0 and len(leaf_nodes) > 0:
+                    logger.warning("Clustering returned 0 modules - creating synthetic modules to prevent context overflow")
+                    max_per_module = int(os.environ.get('CODEWIKI_MAX_FILES_PER_MODULE', '5'))
+                    synthetic_modules = {}
+
+                    for i in range(0, len(leaf_nodes), max_per_module):
+                        batch = leaf_nodes[i:i + max_per_module]
+                        module_name = f"module_{i // max_per_module + 1}"
+                        synthetic_modules[module_name] = {
+                            "name": module_name,
+                            "components": [node.name for node in batch],
+                            "leaf_nodes": batch
+                        }
+
+                    module_tree = synthetic_modules
+                    logger.info(f"Created {len(module_tree)} synthetic modules ({max_per_module} files each)")
+                # === END SYNTHETIC_MODULE_PATCH ===
+
                 file_manager.save_json(module_tree, first_module_tree_path)
             
             file_manager.save_json(module_tree, module_tree_path)


### PR DESCRIPTION
## Summary

- Fixes silent failure when `cluster_modules()` returns 0 modules
- Prevents "whole repo" fallback that exceeds OpenAI/Anthropic context limits
- Creates synthetic modules by grouping files (default: 5 per module)

## Problem

When `cluster_modules()` returns 0 modules (often fails silently), CodeWiki falls back to
processing the entire repository in a single API request. This exceeds OpenAI/Anthropic
context limits, causing **400 Bad Request** errors:

```
Processing whole repo because repo can fit in the context window
openai.BadRequestError: Error code: 400 - This model's maximum context length is 128000 tokens
```

## Solution

After clustering, if `module_tree` is empty but `leaf_nodes` exist, create synthetic modules
by grouping files (max 5 per module by default). This ensures content is chunked appropriately
for API limits.

## Configuration

`CODEWIKI_MAX_FILES_PER_MODULE` env var controls files per module (default: 5)

## Test Plan

- [x] Run CodeWiki on a repo where clustering returns 0 modules
- [ ] Verify log shows: `"Created X synthetic modules (5 files each)"`
- [ ] Verify the 400 Bad Request error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)