### PR TITLE
feat: add .gitignore pattern support for repository analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ codewiki config set \
 # Configure max token settings
 codewiki config set --max-tokens 32768 --max-token-per-module 36369 --max-token-per-leaf-module 16000
 
-# Configure max depth for hierarchical decomposition
-codewiki config set --max-depth 3
+# Configure max depth for hierarchical decomposition and .gitignore support
+codewiki config set --max-depth 3 --respect-gitignore
 
 # Show current configuration
 codewiki config show
@@ -137,7 +137,7 @@ codewiki generate --github-pages
 codewiki generate --verbose
 
 # Full-featured generation
-codewiki generate --create-branch --github-pages --verbose
+codewiki generate --create-branch --github-pages --verbose --respect-gitignore
 ```
 
 ### Customization Options
@@ -145,8 +145,8 @@ codewiki generate --create-branch --github-pages --verbose
 CodeWiki supports customization for language-specific projects and documentation styles:
 
 ```bash
-# C# project: only analyze .cs files, exclude test directories
-codewiki generate --include "*.cs" --exclude "Tests,Specs,*.test.cs"
+# C# project: only analyze .cs files, exclude test directories, respect .gitignore
+codewiki generate --include "*.cs" --exclude "Tests,Specs,*.test.cs" --respect-gitignore
 
 # Focus on specific modules with architecture-style docs
 codewiki generate --focus "src/core,src/api" --doc-type architecture
@@ -157,7 +157,7 @@ codewiki generate --instructions "Focus on public APIs and include usage example
 
 #### Pattern Behavior (Important!)
 
-- **`--include`**: When specified, **ONLY** these patterns are used (replaces defaults completely)
+- **`--include`**: When specified, **ONLY** these patterns are included from the remaining files (applied after exclusion)
   - Example: `--include "*.cs"` will analyze ONLY `.cs` files
   - If omitted, all supported file types are analyzed
   - Supports glob patterns: `*.py`, `src/**/*.ts`, `*.{js,jsx}`
@@ -169,6 +169,14 @@ codewiki generate --instructions "Focus on public APIs and include usage example
     - Exact names: `Tests`, `.env`, `config.local`
     - Glob patterns: `*.test.js`, `*_test.py`, `*.min.*`
     - Directory patterns: `build/`, `dist/`, `coverage/`
+
+- **`--respect-gitignore`**: Respect `.gitignore` patterns
+  - **Hybrid**: Uses `git check-ignore` for full recursive accuracy, falls back to pathspec if git unavailable
+  - **Processing Logic**:
+    1. **Git Check**: If matched by `.gitignore` → **Excluded**
+    2. **User Exclude**: If matched by CLI `--exclude` → **Excluded** (Overrides Git tracking)
+    3. **Defaults**: If no match above → Check default ignore patterns
+    4. **Inclusion**: Final check against `--include` patterns (if specified)
 
 #### Setting Persistent Defaults
 
@@ -201,6 +209,7 @@ codewiki config agent --clear
 | `--focus` | Modules to document in detail | Standalone option | `src/core,src/api` |
 | `--doc-type` | Documentation style | Standalone option | `api`, `architecture`, `user-guide`, `developer` |
 | `--instructions` | Custom agent instructions | Standalone option | Free-form text |
+
 
 ### Token Settings
 

--- a/codewiki/cli/adapters/doc_generator.py
+++ b/codewiki/cli/adapters/doc_generator.py
@@ -141,6 +141,7 @@ class CLIDocumentationGenerator:
                 max_token_per_module=self.config.get('max_token_per_module', 36369),
                 max_token_per_leaf_module=self.config.get('max_token_per_leaf_module', 16000),
                 max_depth=self.config.get('max_depth', 2),
+                respect_gitignore=self.config.get('respect_gitignore', False),
                 agent_instructions=self.config.get('agent_instructions')
             )
             

--- a/codewiki/cli/commands/generate.py
+++ b/codewiki/cli/commands/generate.py
@@ -126,6 +126,12 @@ def parse_patterns(patterns_str: str) -> List[str]:
     default=None,
     help="Maximum depth for hierarchical decomposition (overrides config)",
 )
+@click.option(
+    '--respect-gitignore',
+    is_flag=True,
+    default=None,
+    help='Respect .gitignore patterns during analysis'
+)
 @click.pass_context
 def generate_command(
     ctx,
@@ -142,7 +148,8 @@ def generate_command(
     max_tokens: Optional[int],
     max_token_per_module: Optional[int],
     max_token_per_leaf_module: Optional[int],
-    max_depth: Optional[int]
+    max_depth: Optional[int],
+    respect_gitignore: Optional[bool]
 ):
     """
     Generate comprehensive documentation for a code repository.
@@ -290,7 +297,8 @@ def generate_command(
             create_branch=create_branch,
             github_pages=github_pages,
             no_cache=no_cache,
-            custom_output=output if output != "docs" else None
+            custom_output=output if output != "docs" else None,
+            respect_gitignore=respect_gitignore if respect_gitignore is not None else config.respect_gitignore
         )
         
         # Create runtime agent instructions from CLI options
@@ -322,10 +330,12 @@ def generate_command(
             effective_max_token_per_module = max_token_per_module if max_token_per_module is not None else config.max_token_per_module
             effective_max_token_per_leaf = max_token_per_leaf_module if max_token_per_leaf_module is not None else config.max_token_per_leaf_module
             effective_max_depth = max_depth if max_depth is not None else config.max_depth
+            effective_respect_gitignore = respect_gitignore if respect_gitignore is not None else config.respect_gitignore
             logger.debug(f"Max tokens: {effective_max_tokens}")
             logger.debug(f"Max token/module: {effective_max_token_per_module}")
             logger.debug(f"Max token/leaf module: {effective_max_token_per_leaf}")
             logger.debug(f"Max depth: {effective_max_depth}")
+            logger.debug(f"Respect gitignore: {effective_respect_gitignore}")
         
         # Get agent instructions (merge runtime with persistent)
         agent_instructions_dict = None
@@ -359,6 +369,8 @@ def generate_command(
                 'max_token_per_leaf_module': max_token_per_leaf_module if max_token_per_leaf_module is not None else config.max_token_per_leaf_module,
                 # Max depth setting (runtime override takes precedence)
                 'max_depth': max_depth if max_depth is not None else config.max_depth,
+                # Gitignore setting (runtime override takes precedence)
+                'respect_gitignore': respect_gitignore if respect_gitignore is not None else config.respect_gitignore,
             },
             verbose=verbose,
             generate_html=github_pages

--- a/codewiki/cli/config_manager.py
+++ b/codewiki/cli/config_manager.py
@@ -92,7 +92,8 @@ class ConfigManager:
         max_tokens: Optional[int] = None,
         max_token_per_module: Optional[int] = None,
         max_token_per_leaf_module: Optional[int] = None,
-        max_depth: Optional[int] = None
+        max_depth: Optional[int] = None,
+        respect_gitignore: Optional[bool] = None,
     ):
         """
         Save configuration to file and keyring.
@@ -108,6 +109,7 @@ class ConfigManager:
             max_token_per_module: Maximum tokens per module for clustering
             max_token_per_leaf_module: Maximum tokens per leaf module
             max_depth: Maximum depth for hierarchical decomposition
+            respect_gitignore: Respect .gitignore patterns during analysis
         """
         # Ensure config directory exists
         try:
@@ -149,7 +151,9 @@ class ConfigManager:
             self._config.max_token_per_leaf_module = max_token_per_leaf_module
         if max_depth is not None:
             self._config.max_depth = max_depth
-        
+        if respect_gitignore is not None:
+            self._config.respect_gitignore = respect_gitignore
+
         # Validate configuration (only if base fields are set)
         if self._config.base_url and self._config.main_model and self._config.cluster_model:
             self._config.validate()

--- a/codewiki/cli/models/config.py
+++ b/codewiki/cli/models/config.py
@@ -118,6 +118,7 @@ class Configuration:
         max_token_per_leaf_module: Maximum tokens per leaf module (default: 16000)
         max_depth: Maximum depth for hierarchical decomposition (default: 2)
         agent_instructions: Custom agent instructions for documentation generation
+        respect_gitignore: Respect .gitignore patterns during analysis
     """
     base_url: str
     main_model: str
@@ -129,6 +130,7 @@ class Configuration:
     max_token_per_leaf_module: int = 16000
     max_depth: int = 2
     agent_instructions: AgentInstructions = field(default_factory=AgentInstructions)
+    respect_gitignore: bool = False
     
     def validate(self):
         """
@@ -153,6 +155,7 @@ class Configuration:
             'max_token_per_module': self.max_token_per_module,
             'max_token_per_leaf_module': self.max_token_per_leaf_module,
             'max_depth': self.max_depth,
+            'respect_gitignore': self.respect_gitignore,
         }
         if self.agent_instructions and not self.agent_instructions.is_empty():
             result['agent_instructions'] = self.agent_instructions.to_dict()
@@ -184,6 +187,7 @@ class Configuration:
             max_token_per_leaf_module=data.get('max_token_per_leaf_module', 16000),
             max_depth=data.get('max_depth', 2),
             agent_instructions=agent_instructions,
+            respect_gitignore=data.get('respect_gitignore', False),
         )
     
     def is_complete(self) -> bool:
@@ -237,6 +241,7 @@ class Configuration:
             max_token_per_module=self.max_token_per_module,
             max_token_per_leaf_module=self.max_token_per_leaf_module,
             max_depth=self.max_depth,
-            agent_instructions=final_instructions.to_dict() if final_instructions else None
+            agent_instructions=final_instructions.to_dict() if final_instructions else None,
+            respect_gitignore=self.respect_gitignore,
         )
 

--- a/codewiki/cli/models/job.py
+++ b/codewiki/cli/models/job.py
@@ -25,6 +25,7 @@ class GenerationOptions:
     github_pages: bool = False
     no_cache: bool = False
     custom_output: Optional[str] = None
+    respect_gitignore: Optional[bool] = None
 
 
 @dataclass

--- a/codewiki/src/be/dependency_analyzer/analysis/repo_analyzer.py
+++ b/codewiki/src/be/dependency_analyzer/analysis/repo_analyzer.py
@@ -8,9 +8,16 @@ detailed file tree representations with filtering capabilities.
 import os
 import fnmatch
 import json
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional, Union
-from codewiki.src.be.dependency_analyzer.utils.patterns import DEFAULT_IGNORE_PATTERNS, DEFAULT_INCLUDE_PATTERNS
+from codewiki.src.be.dependency_analyzer.utils.patterns import (
+    DEFAULT_IGNORE_PATTERNS,
+    DEFAULT_INCLUDE_PATTERNS,
+)
+from pathspec import PathSpec
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 
 class RepoAnalyzer:
@@ -18,6 +25,8 @@ class RepoAnalyzer:
         self,
         include_patterns: Optional[List[str]] = None,
         exclude_patterns: Optional[List[str]] = None,
+        respect_gitignore: bool = False,
+        repo_path: Optional[str] = None,
     ) -> None:
         # Include patterns: if specified, use ONLY those patterns (replaces defaults)
         self.include_patterns = (
@@ -29,9 +38,28 @@ class RepoAnalyzer:
             if exclude_patterns is not None
             else list(DEFAULT_IGNORE_PATTERNS)
         )
+        # User-specified exclude patterns only (separated from defaults)
+        self._user_exclude_patterns = exclude_patterns if exclude_patterns is not None else []
+        self.respect_gitignore = respect_gitignore
+        self.repo_path = repo_path
+        self.gitignore_spec = None
+        self.include_spec = None
+        self._git_path = shutil.which("git")
+        self._git_available = self._check_git_availability()
 
-    def analyze_repository_structure(self, repo_dir: str) -> Dict:
+        if include_patterns:
+            try:
+                self.include_spec = PathSpec.from_lines(GitWildMatchPattern, self.include_patterns)
+            except ImportError:
+                pass
+
+        if self.respect_gitignore:
+            self._load_gitignore_patterns()
+
+    def analyze_repository_structure(self, repo_dir: str) -> Optional[Dict]:
         file_tree = self._build_file_tree(repo_dir)
+        if file_tree is None:
+            return None
         return {
             "file_tree": file_tree,
             "summary": {
@@ -40,7 +68,50 @@ class RepoAnalyzer:
             },
         }
 
-    def _build_file_tree(self, repo_dir: str) -> Dict:
+    def _load_gitignore_patterns(self):
+        if not self.repo_path:
+            self.gitignore_spec = None
+            return
+
+        gitignore_file = os.path.join(self.repo_path, ".gitignore")
+        if os.path.exists(gitignore_file):
+            with open(gitignore_file, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+            self.gitignore_spec = PathSpec.from_lines(GitWildMatchPattern, lines)
+        else:
+            self.gitignore_spec = None
+
+    def _check_git_availability(self) -> bool:
+        if self._git_path is None:
+            return False
+        try:
+            result = subprocess.run([self._git_path, "--version"], capture_output=True, timeout=5)
+            return result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+            return False
+
+    def _is_ignored_by_git(self, path: str) -> Optional[bool]:
+        if not self.repo_path:
+            return None
+
+        if not self._git_available:
+            return None
+
+        assert self._git_path is not None
+
+        try:
+            full_path = os.path.join(self.repo_path, path)
+            result = subprocess.run(
+                [self._git_path, "check-ignore", "--quiet", full_path],
+                cwd=self.repo_path,
+                capture_output=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except (subprocess.SubprocessError, subprocess.TimeoutExpired, FileNotFoundError):
+            return None
+
+    def _build_file_tree(self, repo_dir: str) -> Optional[Dict]:
         def build_tree(path: Path, base_path: Path) -> Optional[Dict]:
             relative_path = path.relative_to(base_path)
             relative_path_str = str(relative_path)
@@ -98,6 +169,34 @@ class RepoAnalyzer:
         return build_tree(Path(repo_dir), Path(repo_dir))
 
     def _should_exclude_path(self, path: str, filename: str) -> bool:
+        if self.respect_gitignore:
+            git_ignored = self._is_ignored_by_git(path)
+
+            if git_ignored is True:
+                return True
+
+            if git_ignored is False:
+                for pattern in self._user_exclude_patterns:
+                    if fnmatch.fnmatch(path, pattern) or fnmatch.fnmatch(filename, pattern):
+                        return True
+                    if pattern.endswith("/") and path.startswith(pattern.rstrip("/")):
+                        return True
+                    if path.startswith(pattern + "/") or path == pattern:
+                        return True
+                    if pattern in path.split("/"):
+                        return True
+                return False
+
+            if (
+                git_ignored is None
+                and hasattr(self, "gitignore_spec")
+                and self.gitignore_spec is not None
+            ):
+                if self.gitignore_spec.match_file(path):
+                    return True
+                if not path.endswith("/") and self.gitignore_spec.match_file(path + "/"):
+                    return True
+
         for pattern in self.exclude_patterns:
             if fnmatch.fnmatch(path, pattern) or fnmatch.fnmatch(filename, pattern):
                 return True
@@ -107,11 +206,16 @@ class RepoAnalyzer:
                 return True
             if pattern in path.split("/"):
                 return True
+
         return False
 
     def _should_include_file(self, path: str, filename: str) -> bool:
         if not self.include_patterns:
             return True
+
+        if self.include_spec and self.include_spec.match_file(path):
+            return True
+
         for pattern in self.include_patterns:
             if fnmatch.fnmatch(path, pattern) or fnmatch.fnmatch(filename, pattern):
                 return True

--- a/codewiki/src/be/dependency_analyzer/analysis/repo_analyzer.py
+++ b/codewiki/src/be/dependency_analyzer/analysis/repo_analyzer.py
@@ -185,7 +185,7 @@ class RepoAnalyzer:
                         return True
                     if pattern in path.split("/"):
                         return True
-                return False
+                # Allow default ignore patterns to be checked (remove early return)
 
             if (
                 git_ignored is None

--- a/codewiki/src/be/dependency_analyzer/ast_parser.py
+++ b/codewiki/src/be/dependency_analyzer/ast_parser.py
@@ -18,7 +18,7 @@ logger.setLevel(logging.DEBUG)
 class DependencyParser:
     """Parser for extracting code components from multi-language repositories."""
     
-    def __init__(self, repo_path: str, include_patterns: List[str] = None, exclude_patterns: List[str] = None):
+    def __init__(self, repo_path: str, include_patterns: List[str] = None, exclude_patterns: List[str] = None,respect_gitignore: bool = False):
         """
         Initialize the dependency parser.
         
@@ -26,13 +26,14 @@ class DependencyParser:
             repo_path: Path to the repository
             include_patterns: File patterns to include (e.g., ["*.cs", "*.py"])
             exclude_patterns: File/directory patterns to exclude (e.g., ["*Tests*"])
+            respect_gitignore: Whether to respect .gitignore patterns
         """
         self.repo_path = os.path.abspath(repo_path)
         self.components: Dict[str, Node] = {}
         self.modules: Set[str] = set()
         self.include_patterns = include_patterns
         self.exclude_patterns = exclude_patterns
-        
+        self.respect_gitignore = respect_gitignore
         self.analysis_service = AnalysisService()
 
     def parse_repository(self, filtered_folders: List[str] = None) -> Dict[str, Node]:
@@ -43,11 +44,14 @@ class DependencyParser:
             logger.info(f"Using custom include patterns: {self.include_patterns}")
         if self.exclude_patterns:
             logger.info(f"Using custom exclude patterns: {self.exclude_patterns}")
-        
+        if self.respect_gitignore:
+            logger.info(f"Respecting .gitignore patterns")
+
         structure_result = self.analysis_service._analyze_structure(
-            self.repo_path, 
+            self.repo_path,
             include_patterns=self.include_patterns,
-            exclude_patterns=self.exclude_patterns
+            exclude_patterns=self.exclude_patterns,
+            respect_gitignore=self.respect_gitignore,
         )
         
         call_graph_result = self.analysis_service._analyze_call_graph(

--- a/codewiki/src/be/dependency_analyzer/dependency_graphs_builder.py
+++ b/codewiki/src/be/dependency_analyzer/dependency_graphs_builder.py
@@ -44,7 +44,8 @@ class DependencyGraphBuilder:
         parser = DependencyParser(
             self.config.repo_path,
             include_patterns=include_patterns,
-            exclude_patterns=exclude_patterns
+            exclude_patterns=exclude_patterns,
+            respect_gitignore=self.config.respect_gitignore,
         )
 
         filtered_folders = None

--- a/codewiki/src/config.py
+++ b/codewiki/src/config.py
@@ -63,7 +63,9 @@ class Config:
     max_token_per_leaf_module: int = DEFAULT_MAX_TOKEN_PER_LEAF_MODULE
     # Agent instructions for customization
     agent_instructions: Optional[Dict[str, Any]] = None
-    
+    # Git integration
+    respect_gitignore: bool = False
+
     @property
     def include_patterns(self) -> Optional[List[str]]:
         """Get file include patterns from agent instructions."""
@@ -131,7 +133,8 @@ class Config:
         """Create configuration from parsed arguments."""
         repo_name = os.path.basename(os.path.normpath(args.repo_path))
         sanitized_repo_name = ''.join(c if c.isalnum() else '_' for c in repo_name)
-        
+        respect_gitignore = getattr(args, 'respect_gitignore', False)
+
         return cls(
             repo_path=args.repo_path,
             output_dir=OUTPUT_BASE_DIR,
@@ -142,7 +145,8 @@ class Config:
             llm_api_key=LLM_API_KEY,
             main_model=MAIN_MODEL,
             cluster_model=CLUSTER_MODEL,
-            fallback_model=FALLBACK_MODEL_1
+            fallback_model=FALLBACK_MODEL_1,
+            respect_gitignore=respect_gitignore,
         )
     
     @classmethod
@@ -159,7 +163,8 @@ class Config:
         max_token_per_module: int = DEFAULT_MAX_TOKEN_PER_MODULE,
         max_token_per_leaf_module: int = DEFAULT_MAX_TOKEN_PER_LEAF_MODULE,
         max_depth: int = MAX_DEPTH,
-        agent_instructions: Optional[Dict[str, Any]] = None
+        agent_instructions: Optional[Dict[str, Any]] = None,
+        respect_gitignore: bool = False,
     ) -> 'Config':
         """
         Create configuration for CLI context.
@@ -177,13 +182,14 @@ class Config:
             max_token_per_leaf_module: Maximum tokens per leaf module
             max_depth: Maximum depth for hierarchical decomposition
             agent_instructions: Custom agent instructions dict
-            
+            respect_gitignore: Respect .gitignore patterns during analysis
+
         Returns:
             Config instance
         """
         repo_name = os.path.basename(os.path.normpath(repo_path))
         base_output_dir = os.path.join(output_dir, "temp")
-        
+
         return cls(
             repo_path=repo_path,
             output_dir=base_output_dir,
@@ -198,5 +204,6 @@ class Config:
             max_tokens=max_tokens,
             max_token_per_module=max_token_per_module,
             max_token_per_leaf_module=max_token_per_leaf_module,
-            agent_instructions=agent_instructions
+            agent_instructions=agent_instructions,
+            respect_gitignore=respect_gitignore,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ dependencies = [
     "psutil>=7.0.0",
     "PyYAML>=6.0.2",
     "mermaid-parser-py>=0.0.2",
-    "mermaid-py>=0.8.0"
+    "mermaid-py>=0.8.0",
+    "pathspec>=0.12.0"
 ]
 
 [external]

--- a/tests/test_gitignore_verification.py
+++ b/tests/test_gitignore_verification.py
@@ -1,0 +1,70 @@
+import tempfile
+import subprocess
+import shutil
+import sys
+import os
+from pathlib import Path
+
+
+def main() -> None:
+    if not Path("codewiki").exists():
+        print("Please run this script from the project root directory.")
+        sys.exit(1)
+    sys.path.insert(0, os.getcwd())
+
+    from codewiki.src.be.dependency_analyzer.analysis.repo_analyzer import RepoAnalyzer
+
+    git_cmd = shutil.which("git")
+    if git_cmd is None:
+        print("Error: git command not found. Please install git.")
+        sys.exit(1)
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="codewiki_verification_"))
+    print(f"Creating test fixtures in: {temp_dir}")
+
+    try:
+        subprocess.run([git_cmd, "init", "-q"], cwd=temp_dir, check=True)
+        (temp_dir / ".gitignore").write_text("node_modules/\n*.log\n!important.log")
+        (temp_dir / "backend").mkdir()
+        (temp_dir / "backend" / ".gitignore").write_text("secrets.py")
+
+        (temp_dir / "app.log").touch()
+        (temp_dir / "important.log").touch()
+        (temp_dir / "backend" / "secrets.py").touch()
+        (temp_dir / "backend" / "api.py").touch()
+        (temp_dir / "force_exclude.py").touch()
+
+        print("-" * 60)
+        print("TEST 1: Gitignore Logic (Negation & Nested)")
+        analyzer = RepoAnalyzer(respect_gitignore=True, repo_path=str(temp_dir))
+
+        check1 = analyzer._should_exclude_path("app.log", "app.log") is True
+        check2 = analyzer._should_exclude_path("important.log", "important.log") is False
+        check3 = analyzer._should_exclude_path("backend/secrets.py", "secrets.py") is True
+
+        print(f"  [{'✅' if check1 else '❌'}] Basic pattern (*.log)")
+        print(f"  [{'✅' if check2 else '❌'}] Negation pattern (!important.log)")
+        print(f"  [{'✅' if check3 else '❌'}] Nested .gitignore")
+
+        print("\nTEST 2: Priority Logic (CLI Override > Git)")
+        analyzer_override = RepoAnalyzer(
+            respect_gitignore=True, repo_path=str(temp_dir), exclude_patterns=["force_exclude.py"]
+        )
+        check4 = (
+            analyzer_override._should_exclude_path("force_exclude.py", "force_exclude.py") is True
+        )
+        print(f"  [{'✅' if check4 else '❌'}] CLI --exclude overrides Git tracking")
+
+        if all([check1, check2, check3, check4]):
+            print("\n✨ ALL CHECKS PASSED")
+            sys.exit(0)
+        else:
+            print("\n🚫 SOME CHECKS FAILED")
+            sys.exit(1)
+
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR splits out a feature from the fork branch referenced in #28  as an initial contribution🙏
Welcome to review and provide suggestions. I'm happy to make adjustments as needed

PR report(from DeepWiki team): https://app.devin.ai/review/FSoft-AI4Code/CodeWiki/pull/35

## TLDR

Adds support for respecting `.gitignore` patterns during repository analysis. Uses `git check-ignore` when available with fallback to pathspec library.

**Examples:**

```bash
# Enable gitignore respect
codewiki generate --respect-gitignore

# Save as default setting
codewiki config set --respect-gitignore
```
## Dive Deeper
### Key Changes

##### **repo_analyzer.py**
- Added `_user_exclude_patterns` to distinguish user-specified vs default excludes
- Implemented three-tier priority logic for `respect_gitignore`:
  1. Git ignores (returns True) → exclude file
  2. Git doesn't ignore (returns False) → check user-specified excludes, then DEFAULT_IGNORE_PATTERNS
  3. Git unavailable (returns None) → fallback to .gitignore file via pathspec
- Modified `_should_include_file` to use pathspec matching for include patterns
- **Bug fix**: Ensure DEFAULT_IGNORE_PATTERNS are checked when git returns False (line 188)

##### **analysis_service.py**
- Added `None` checks in `analyze_local_repository` and `_analyze_structure`
- Returns empty structure on failure/exclusion to prevent crashes

### How It Works

1. **Git available**: Uses `git check-ignore` command for full recursive accuracy
2. **Git unavailable**: Falls back to pathspec library for root-only `.gitignore` matching
3. **Features**: Handles nested `.gitignore` files, pattern negation (`!pattern`), and complex patterns
4. **DEFAULT_IGNORE_PATTERNS**: Always checked for patterns like `.git`, `*.pyc`, `__pycache__/`, `node_modules/`, etc.

**Exclusion priority:**
1. Git ignore (if `--respect-gitignore` enabled and git says ignored) → exclude
2. User-specified excludes (CLI `--exclude`) → exclude
3. `.gitignore` file (if `--respect-gitignore` enabled) → exclude
4. **DEFAULT_IGNORE_PATTERNS** (always checked) → exclude

**Use cases:**
- **Node.js projects**: Excludes `node_modules/`, `build/`, `.env`, `*.log`
- **Python projects**: Excludes `__pycache__/`, `*.pyc`, `.venv/`, `*.egg-info/`
- **Custom patterns**: All patterns in your `.gitignore` file are respected
- **Default exclusions**: Git internals (`.git/`), caches, logs, and other standard patterns always excluded

---

## Reviewer Test Plan Suggestions

### 1. Check Documentation

You can review the changes in `README.md` to verify accuracy and clarity:

```bash
git show HEAD -- README.md
```

### 2. Verify Gitignore Behavior

You can run this script to verify hybrid strategy and priority logic:

```bash
python tests/test_gitignore_verification.py
```

The test script verifies:
- Basic gitignore patterns (*.log)
- Multiple log files excluded by DEFAULT_IGNORE_PATTERNS
- Nested .gitignore files
- CLI --exclude overrides Git tracking

Output:
<details>
<img width="764" height="205" alt="截圖 2026-01-20 上午11 12 39" src="https://github.com/user-attachments/assets/0f36b098-0c69-442a-9567-bf000a4dfe4b" />
</details>

### 3. Runtime Check

You can verify the CLI configuration loads the flag correctly:

```bash
codewiki config show
# Should show: "Respect Gitignore: True" when set

codewiki generate --help | grep -i "gitignore"
# Should show the --respect-gitignore option
```
Output:
<details>
<img width="268" height="245" alt="截圖 2026-01-20 上午11 13 28" src="https://github.com/user-attachments/assets/fed2b3b6-9c26-45d9-b691-bab66d58000d" />
<img width="743" height="65" alt="截圖 2026-01-20 上午11 14 10" src="https://github.com/user-attachments/assets/0dfb5c7f-98c4-4cc6-b8fa-5fd62af4f439" />
</details>