### PR TITLE
fix(tool-args): coerce JSON-encoded strings on str_replace_editor numeric args

### DIFF
--- a/codewiki/src/be/agent_tools/str_replace_editor.py
+++ b/codewiki/src/be/agent_tools/str_replace_editor.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Optional, Tuple, Literal
+from typing import Annotated, List, Literal, Optional, Tuple
 import io
 
 import logging
@@ -19,10 +19,34 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+from pydantic import BeforeValidator
 from pydantic_ai import RunContext, Tool
 
 from .deps import CodeWikiDeps
 from ..utils import validate_mermaid_diagrams
+
+
+def _coerce_json_string(value):
+    """Coerce a JSON encoded string to its parsed Python value before pydantic
+    strict validation runs. No op on already typed values.
+
+    Some local models routed through OpenAI compatible endpoints (LiteLLM,
+    vLLM, Ollama, etc.) emit list and int tool args as JSON encoded strings
+    (e.g. `"[1, 50]"` instead of `[1, 50]`) which strict pydantic validation
+    rejects. This validator parses them so the tool accepts both shapes.
+    Anthropic native API users are unaffected because they already emit
+    structured values.
+    """
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return value
+
+
+ViewRange = Annotated[Optional[List[int]], BeforeValidator(_coerce_json_string)]
+InsertLine = Annotated[Optional[int], BeforeValidator(_coerce_json_string)]
 
 
 # There are some super strange "ascii can't decode x" errors,
@@ -713,10 +737,10 @@ async def str_replace_editor(
     path: Optional[str] = None,
     file: Optional[str] = None,
     file_text: Optional[str] = None,
-    view_range: Optional[List[int]] = None,
+    view_range: ViewRange = None,
     old_str: Optional[str] = None,
     new_str: Optional[str] = None,
-    insert_line: Optional[int] = None,
+    insert_line: InsertLine = None,
 ) -> str:
     """
     Custom editing tool for viewing, creating and editing files


### PR DESCRIPTION
## Summary

Fix `str_replace_editor` tool argument validation when CodeWiki runs against an OpenAI compatible backend (LiteLLM, vLLM, Ollama, etc.) instead of native Anthropic.

## Problem

Some local models emit list-typed and int-typed tool arguments as JSON-encoded strings rather than proper structured values:

```json
{
  "command": "view",
  "path": "/repo/foo.py",
  "view_range": "[1, 50]"   ← string, not array
}
```

Pydantic strict validation in pydantic-ai then rejects the call with:

```
ValidationError: 1 validation error for str_replace_editor
view_range
  Input should be a valid array
  [type=list_type, input_value='[1, 50]', input_type=str]
```

After the configured `max_retries`, the run aborts with `UnexpectedModelBehavior: Tool 'str_replace_editor' exceeded max retries`. The same model under reasoning enabled mode hits this consistently.

This makes CodeWiki effectively unusable on local LLM stacks, even though `--provider openai-compatible` is documented as a supported configuration.

## Fix

Add a Pydantic `BeforeValidator` that parses a JSON-encoded string back into its structured form before strict validation runs. Applied to the two args observed to fail in practice: `view_range` (list) and `insert_line` (int).

```python
def _coerce_json_string(value):
    if isinstance(value, str):
        try:
            return json.loads(value)
        except (json.JSONDecodeError, ValueError):
            pass
    return value


ViewRange = Annotated[Optional[List[int]], BeforeValidator(_coerce_json_string)]
InsertLine = Annotated[Optional[int], BeforeValidator(_coerce_json_string)]
```

The validator is a *no-op* when the value is already typed correctly. Anthropic native API users (whose tool calls already arrive as structured JSON) see no behavior change.

## Empirical validation

Same model, same prompt, same target repo. The only change between runs is this patch:

- *Before patch:* `Tool 'str_replace_editor' exceeded max retries count of 1`. Generation aborted at the documentation phase. Reproduced on two different OpenAI compatible local models.
- *After patch:* Documentation generation completed in 3 minutes 21 seconds. All expected pages produced. Banner intact, no `Table of Contents` duplicates.

The runtime check inside `EditTool.view` (`len(view_range) != 2 or not all(isinstance(i, int) for i in view_range)`) still rejects malformed values that happen to slip through the JSON parse, so the failure surface is unchanged for genuinely bad input.

## Test plan

- [x] `python -c "import ast; ast.parse(open('codewiki/src/be/agent_tools/str_replace_editor.py').read())"` parses clean.
- [x] End to end documentation generation against an OpenAI compatible local model produces the expected output tree.
- [x] No regression for Anthropic native runs (validator is a no-op on typed input).

## Related

This addresses a class of issue similar to [#50](https://github.com/FSoft-AI4Code/CodeWiki/pull/50) (fallback-model persistence). Both surface as "configuration says X is supported but X breaks at runtime."
