### PR TITLE
feat: Add --compare-to option to override commit hash for incremental updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ codewiki generate --create-branch --github-pages --verbose
 
 # Incremental update (only regenerate changed modules since last run)
 codewiki generate --update
+
+# Incremental update using a specific commit hash to compare against (useful in CI/CD or squashed PRs)
+# This overrides the stored commit hash in metadata.json and implicitly enables --update
+codewiki generate --compare-to <commit-hash>
 ```
 
 ### Customization Options

--- a/codewiki/cli/commands/generate.py
+++ b/codewiki/cli/commands/generate.py
@@ -43,7 +43,8 @@ def _detect_changed_files(
     repo_path: Path,
     output_dir: Path,
     logger,
-    verbose: bool
+    verbose: bool,
+    compare_to: Optional[str] = None
 ) -> Optional[List[str]]:
     """
     Detect files changed since the last documentation generation.
@@ -57,21 +58,25 @@ def _detect_changed_files(
     """
     import json
 
-    metadata_path = output_dir / "metadata.json"
-    if not metadata_path.exists():
-        if verbose:
-            logger.debug("No metadata.json found — cannot detect changes, running full generation.")
-        return None
-
-    try:
-        metadata = json.loads(metadata_path.read_text())
-        prev_commit = metadata.get("generation_info", {}).get("commit_id")
-        if not prev_commit:
+    prev_commit = None
+    if compare_to:
+        prev_commit = compare_to
+    else:
+        metadata_path = output_dir / "metadata.json"
+        if not metadata_path.exists():
             if verbose:
-                logger.debug("No commit_id in metadata — running full generation.")
+                logger.debug("No metadata.json found — cannot detect changes, running full generation.")
             return None
-    except (json.JSONDecodeError, OSError):
-        return None
+
+        try:
+            metadata = json.loads(metadata_path.read_text())
+            prev_commit = metadata.get("generation_info", {}).get("commit_id")
+            if not prev_commit:
+                if verbose:
+                    logger.debug("No commit_id in metadata — running full generation.")
+                return None
+        except (json.JSONDecodeError, OSError):
+            return None
 
     # Get current HEAD commit
     try:
@@ -295,6 +300,12 @@ def _invalidate_affected_modules(
     is_flag=True,
     help="Incremental update: only regenerate modules affected by changes since last generation",
 )
+@click.option(
+    "--compare-to",
+    type=str,
+    default=None,
+    help="Commit hash to compare against for incremental updates (overrides stored commit in metadata.json)",
+)
 @click.pass_context
 def generate_command(
     ctx,
@@ -312,7 +323,8 @@ def generate_command(
     max_token_per_module: Optional[int],
     max_token_per_leaf_module: Optional[int],
     max_depth: Optional[int],
-    update: bool = False
+    update: bool = False,
+    compare_to: Optional[str] = None
 ):
     """
     Generate comprehensive documentation for a code repository.
@@ -416,10 +428,14 @@ def generate_command(
         
         logger.success(f"Output directory: {output_dir}")
         
+        # If a base commit is specified to compare against, implicitly enable update
+        if compare_to:
+            update = True
+
         # Incremental update: detect changed files and selectively regenerate
         changed_files = None
         if update and output_dir.exists():
-            changed_files = _detect_changed_files(repo_path, output_dir, logger, verbose)
+            changed_files = _detect_changed_files(repo_path, output_dir, logger, verbose, compare_to=compare_to)
             if changed_files is not None and len(changed_files) == 0:
                 logger.success("No changes detected since last generation. Documentation is up to date.")
                 sys.exit(EXIT_SUCCESS)


### PR DESCRIPTION
## TL;DR

This PR adds a new `--compare-to <commit-hash>` CLI option to the `generate` command, allowing developers to explicitly specify the base commit to compare against when running incremental updates.

## Description

Previously, incremental updates relied solely on the `commit_id` stored in `metadata.json` from the last generation run. This works well for local, continuous workflows but breaks down in CI/CD pipelines or after squashed PR merges, where the stored commit hash may no longer represent the correct baseline for detecting changes.

This pull request introduces a `--compare-to` flag that overrides the stored commit hash and uses a user-supplied commit as the diff baseline. When provided, the flag implicitly enables `--update` mode, so users do not need to pass both flags.

### Key Changes:

- **CLI Option (`generate.py`):**
  - Added a new `--compare-to <commit-hash>` option to the `generate` command.
  - When set, it implicitly enables `--update`, simplifying the command invocation for CI/CD usage.

- **Change Detection (`generate.py`):**
  - Updated `_detect_changed_files` to accept an optional `compare_to` argument.
  - When `compare_to` is provided, it is used directly as `prev_commit`, bypassing the read of `metadata.json` and its stored `commit_id`.
  - Preserved the existing fallback behavior (reading from `metadata.json`) when `--compare-to` is not supplied.

- **Documentation (`README.md`):**
  - Added a usage example demonstrating `codewiki generate --compare-to <commit-hash>`, including a note that it is useful in CI/CD or squashed PR scenarios.
