### PR TITLE
Add Atlas Cloud as a supported LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ codewiki --version
 
 ### 2. Configure Your Environment
 
-CodeWiki supports multiple LLM providers: **OpenAI-compatible**, **Anthropic**, **AWS Bedrock**, **Azure OpenAI**, plus subscription mode via **Claude Code** and **Codex** CLIs (no API key required).
+CodeWiki supports multiple LLM providers: **OpenAI-compatible**, **Atlas Cloud**, **Anthropic**, **AWS Bedrock**, **Azure OpenAI**, plus subscription mode via **Claude Code** and **Codex** CLIs (no API key required).
 
 ```bash
 # OpenAI-compatible
@@ -59,6 +59,14 @@ codewiki config set \
   --main-model claude-sonnet-4 \
   --cluster-model claude-sonnet-4 \
   --fallback-model glm-4p5
+
+# Atlas Cloud — base URL auto-set to https://api.atlascloud.ai/v1;
+# API key read from $ATLASCLOUD_API_KEY when --api-key is omitted.
+codewiki config set \
+  --provider atlas-cloud \
+  --main-model anthropic/claude-sonnet-4.6 \
+  --cluster-model anthropic/claude-sonnet-4.6 \
+  --fallback-model zai-org/GLM-4.6
 
 # Anthropic
 codewiki config set \
@@ -99,6 +107,8 @@ codewiki config set \
   --main-model gpt-5.4 \
   --cluster-model gpt-5.5
 ```
+
+**About Atlas Cloud.** [Atlas Cloud](https://www.atlascloud.ai) is a full-modal AI inference platform that exposes LLM, image, and video models (300+) behind a single OpenAI-compatible API, so it works with CodeWiki out of the box. Browse model IDs at the [models endpoint](https://api.atlascloud.ai/v1/models) and pick a strong coding model for `--main-model` / `--cluster-model`; their [coding plan](https://www.atlascloud.ai/console/coding-plan) offers budget-friendly API access.
 
 **Subscription mode** routes every LLM call through the local `claude` / `codex` CLI binary (via the [`caw`](https://github.com/zzjas/caw) library), so you can run CodeWiki on a Claude Pro/Max or Codex subscription instead of paying per-token API usage. Claude Code's built-in `Write`/`Edit`/`Bash` tools are disabled inside CodeWiki's agent loop so documentation writes still go through CodeWiki's Mermaid-validating editor.
 

--- a/codewiki/cli/commands/config.py
+++ b/codewiki/cli/commands/config.py
@@ -3,6 +3,7 @@ Configuration commands for CodeWiki CLI.
 """
 
 import json
+import os
 import sys
 import click
 from typing import Optional, List
@@ -86,11 +87,12 @@ def config_group():
 @click.option(
     "--provider",
     type=click.Choice(
-        ['openai-compatible', 'anthropic', 'bedrock', 'azure-openai', 'claude-code', 'codex'],
+        ['openai-compatible', 'atlas-cloud', 'anthropic', 'bedrock', 'azure-openai', 'claude-code', 'codex'],
         case_sensitive=False,
     ),
     help=(
         "LLM provider type (default: openai-compatible). "
+        "Use 'atlas-cloud' for Atlas Cloud (base URL auto-set; reads ATLASCLOUD_API_KEY). "
         "Use 'claude-code' or 'codex' to run on a CLI subscription instead of an API key."
     ),
 )
@@ -140,6 +142,11 @@ def config_set(
         --main-model claude-sonnet-4 --cluster-model claude-sonnet-4 --fallback-model glm-4p5
 
     \b
+    # Atlas Cloud (OpenAI-compatible) — base URL auto-set,
+    # API key read from ATLASCLOUD_API_KEY if --api-key is omitted
+    $ codewiki config set --provider atlas-cloud --main-model <atlas-model> --cluster-model <atlas-model>
+
+    \b
     # Subscription mode (Claude Code) — no API key needed,
     # authenticate via 'claude login' on the host first
     $ codewiki config set --provider claude-code --main-model claude-sonnet-4-5
@@ -169,7 +176,17 @@ def config_set(
         if not any([api_key, base_url, main_model, cluster_model, fallback_model, max_tokens, max_token_per_module, max_token_per_leaf_module, max_depth, provider, aws_region, api_version, azure_deployment]):
             click.echo("No options provided. Use --help for usage information.")
             sys.exit(EXIT_CONFIG_ERROR)
-        
+
+        # Atlas Cloud convenience defaults: it's an OpenAI-compatible endpoint, so
+        # auto-fill its base URL and pull the API key from ATLASCLOUD_API_KEY when the
+        # user does not pass them explicitly.
+        if provider and provider.lower() == "atlas-cloud":
+            from codewiki.src.config import ATLAS_CLOUD_BASE_URL
+            if not base_url:
+                base_url = ATLAS_CLOUD_BASE_URL
+            if not api_key:
+                api_key = os.getenv("ATLASCLOUD_API_KEY")
+
         # Validate inputs before saving
         validated_data = {}
         

--- a/codewiki/cli/models/config.py
+++ b/codewiki/cli/models/config.py
@@ -113,7 +113,7 @@ class Configuration:
         cluster_model: Model for module clustering
         fallback_model: Fallback model for documentation generation
         default_output: Default output directory
-        provider: LLM provider type (openai-compatible, anthropic, bedrock, azure-openai)
+        provider: LLM provider type (openai-compatible, atlas-cloud, anthropic, bedrock, azure-openai)
         aws_region: AWS region for Bedrock provider
         api_version: Azure OpenAI API version
         azure_deployment: Azure OpenAI deployment name

--- a/codewiki/src/config.py
+++ b/codewiki/src/config.py
@@ -43,6 +43,10 @@ CLUSTER_MODEL = os.getenv('CLUSTER_MODEL', MAIN_MODEL)
 LLM_BASE_URL = os.getenv('LLM_BASE_URL', 'http://0.0.0.0:4000/')
 LLM_API_KEY = os.getenv('LLM_API_KEY', 'sk-1234')
 
+# Atlas Cloud default endpoint (OpenAI-compatible). Used to auto-fill the base URL
+# when the user selects the `atlas-cloud` provider without passing --base-url.
+ATLAS_CLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
+
 @dataclass
 class Config:
     """Configuration class for CodeWiki."""
@@ -58,7 +62,7 @@ class Config:
     cluster_model: str
     fallback_model: str = FALLBACK_MODEL_1
     # Provider configuration
-    provider: str = "openai-compatible"  # openai-compatible, anthropic, bedrock, azure-openai
+    provider: str = "openai-compatible"  # openai-compatible, atlas-cloud, anthropic, bedrock, azure-openai
     aws_region: str = "us-east-1"
     api_version: str = "2024-12-01-preview"  # Azure OpenAI API version
     azure_deployment: str = ""  # Azure OpenAI deployment name
@@ -181,7 +185,7 @@ class Config:
             main_model: Primary model
             cluster_model: Clustering model
             fallback_model: Fallback model
-            provider: LLM provider type (openai-compatible, anthropic, bedrock, azure-openai)
+            provider: LLM provider type (openai-compatible, atlas-cloud, anthropic, bedrock, azure-openai)
             aws_region: AWS region for Bedrock provider
             api_version: Azure OpenAI API version
             azure_deployment: Azure OpenAI deployment name


### PR DESCRIPTION
## Summary

Adds [Atlas Cloud](https://www.atlascloud.ai) as a first-class, branded LLM provider
(`--provider atlas-cloud`). Atlas Cloud is a full-modal AI inference platform that exposes
LLM, image, and video models (300+) behind a single **OpenAI-compatible** API, so this
integration reuses CodeWiki's existing OpenAI-compatible code path — **no new backend and
no new dependency**.

Selecting `atlas-cloud` adds two conveniences over the generic `openai-compatible` flow:
- the base URL is auto-set to `https://api.atlascloud.ai/v1`, and
- the API key is read from `ATLASCLOUD_API_KEY` when `--api-key` is omitted.

## Changes

- **`codewiki/cli/commands/config.py`** — add `atlas-cloud` to the `--provider` choices and
  help text; add a convenience block that fills the base URL and reads `ATLASCLOUD_API_KEY`
  when those flags are omitted (values still pass through the existing `validate_url` /
  `validate_api_key` helpers); add a docstring example; import `os`.
- **`codewiki/src/config.py`** — add the `ATLAS_CLOUD_BASE_URL` constant and list
  `atlas-cloud` in the provider docstrings.
- **`codewiki/cli/models/config.py`** — list `atlas-cloud` in the `Configuration` docstring.
- **`README.md`** — list Atlas Cloud among the supported providers, add a config example, and
  a short "About Atlas Cloud" blurb with links (equal footing with the other providers).