### PR TITLE
fix(claude-code): subscription mode silently generates empty docs when bypassPermissions is unavailable

### DIFF
--- a/codewiki/src/be/caw_backend.py
+++ b/codewiki/src/be/caw_backend.py
@@ -120,6 +120,63 @@ _patch_codex_tool_timeout()
 # --- end stopgap --------------------------------------------------------------
 
 
+# --- claude-code allowedTools stopgap -----------------------------------------
+# Custom MCP-server tools (added via `--mcp-config`) are not auto-approved under
+# `acceptEdits`, and `bypassPermissions` may be disabled by an org managed
+# policy (see the cwd note below), so caw's `--dangerously-skip-permissions`
+# alone is not enough: CodeWiki's own toolkit (str_replace_editor,
+# read_code_components, generate_sub_module_documentation) gets denied
+# ("you haven't granted it yet"), the agent writes nothing, and the run
+# "succeeds" with an empty module tree.  Grant the toolkit explicitly with
+# `--allowedTools` using the permission rule syntax:
+#   https://code.claude.com/docs/en/settings#permission-rule-syntax
+#   `--allowedTools` flag: https://code.claude.com/docs/en/cli-reference
+# caw's ClaudeCodeSession only ever emits `--disallowedTools`, so wrap
+# subprocess.Popen to inject `--allowedTools mcp__<server>` for every server in
+# the --mcp-config.  Belongs upstream in caw; remove once it grows a
+# first-class allowed_tools knob for its toolkit servers.
+_CLAUDE_ALLOWED_PATCH_APPLIED = False
+
+
+def _patch_claude_allowed_tools() -> None:
+    global _CLAUDE_ALLOWED_PATCH_APPLIED
+    if _CLAUDE_ALLOWED_PATCH_APPLIED:
+        return
+    import json as _json
+    import subprocess as _sp
+
+    _orig_popen = _sp.Popen
+
+    def _popen(cmd, *args, **kwargs):
+        try:
+            if (
+                isinstance(cmd, (list, tuple))
+                and cmd
+                and os.path.basename(str(cmd[0])) == "claude"
+                and "--mcp-config" in cmd
+                and "--allowedTools" not in cmd
+                and "--allowed-tools" not in cmd
+            ):
+                cfg_path = cmd[list(cmd).index("--mcp-config") + 1]
+                servers = list(
+                    _json.load(open(cfg_path)).get("mcpServers", {}).keys()
+                )
+                if servers:
+                    allowed = ",".join(f"mcp__{s}" for s in servers)
+                    cmd = list(cmd) + ["--allowedTools", allowed]
+                    logger.info("Injected --allowedTools for MCP servers: %s", servers)
+        except Exception as e:  # never break the spawn on a patch hiccup
+            logger.warning("claude allowedTools patch skipped: %s", e)
+        return _orig_popen(cmd, *args, **kwargs)
+
+    _sp.Popen = _popen
+    _CLAUDE_ALLOWED_PATCH_APPLIED = True
+
+
+_patch_claude_allowed_tools()
+# --- end stopgap --------------------------------------------------------------
+
+
 class CawBackend(LLMBackend):
     """Routes LLM operations through the claude / codex CLI subscription."""
 
@@ -304,9 +361,34 @@ class CawBackend(LLMBackend):
         # they're cwd-independent.  Safe to mutate process-wide cwd because
         # documentation_generator processes modules sequentially and recursive
         # _run_module_agent_sync calls chdir to the same absolute_docs_path.
+        # caw runs claude with `--dangerously-skip-permissions`, expecting
+        # bypassPermissions ("Everything" runs without asking).  But an org
+        # managed policy can DISABLE bypass mode, in which case the flag is
+        # downgraded to `acceptEdits` — observed here: both
+        # `--dangerously-skip-permissions` and `--permission-mode
+        # bypassPermissions` report permissionMode=acceptEdits.
+        #   permission modes: https://code.claude.com/docs/en/permission-modes
+        #   (see #skip-all-checks-with-bypasspermissions-mode and its
+        #    disableBypassPermissionsMode managed setting).
+        # Under acceptEdits, auto-approval is limited to reads/edits INSIDE the
+        # working directory or additionalDirectories; paths outside that scope
+        # still prompt (== denied in non-interactive `-p`):
+        #   https://code.claude.com/docs/en/permission-modes#auto-approve-file-edits-with-acceptedits-mode
+        # caw chdir's into the output subdir (for codex's native file_change),
+        # so the source tree in the PARENT repo is out-of-scope and every
+        # source Read is denied -> empty docs.  claude writes via CodeWiki's
+        # str_replace_editor (absolute deps path), so it does NOT need cwd
+        # pinned to the output dir.  Pin cwd to the repo root so BOTH the source
+        # tree and the output dir fall inside the workspace (alt: --add-dir,
+        # https://code.claude.com/docs/en/cli-reference).  Codex keeps the
+        # output-dir chdir because its file_change resolves relative paths.
         original_cwd = os.getcwd()
+        if self._caw_provider == "codex":
+            run_cwd = working_dir
+        else:
+            run_cwd = str(os.path.abspath(config.repo_path))
         try:
-            os.chdir(working_dir)
+            os.chdir(run_cwd)
             try:
                 traj = agent.completion(user_prompt)
             finally:

--- a/codewiki/src/be/caw_backend.py
+++ b/codewiki/src/be/caw_backend.py
@@ -131,45 +131,72 @@ _patch_codex_tool_timeout()
 # `--allowedTools` using the permission rule syntax:
 #   https://code.claude.com/docs/en/settings#permission-rule-syntax
 #   `--allowedTools` flag: https://code.claude.com/docs/en/cli-reference
-# caw's ClaudeCodeSession only ever emits `--disallowedTools`, so wrap
-# subprocess.Popen to inject `--allowedTools mcp__<server>` for every server in
-# the --mcp-config.  Belongs upstream in caw; remove once it grows a
-# first-class allowed_tools knob for its toolkit servers.
+# caw's ClaudeCodeSession only ever emits `--disallowedTools`, so rewrite its
+# `claude` command to add `--allowedTools mcp__<server>` for every server in
+# the --mcp-config.  The patch swaps the `subprocess` module reference INSIDE
+# caw.providers.claude_code for a thin proxy — the global subprocess.Popen
+# class stays untouched (isinstance / subclass safe) and no other claude
+# invocation in this process is affected.  Belongs upstream in caw; remove
+# once it grows a first-class allowed_tools knob for its toolkit servers.
 _CLAUDE_ALLOWED_PATCH_APPLIED = False
+
+
+def _with_allowed_tools(cmd):
+    """Append ``--allowedTools mcp__<server>,...`` to a ``claude`` command.
+
+    Pure ``list -> list`` transform.  Applies only when *cmd* is a claude
+    invocation carrying ``--mcp-config`` and no explicit allow-list already;
+    otherwise (or on any error) *cmd* is returned unchanged.
+    """
+    import json
+
+    try:
+        if not (
+            isinstance(cmd, (list, tuple))
+            and cmd
+            and os.path.basename(str(cmd[0])) == "claude"
+            and "--mcp-config" in cmd
+            and "--allowedTools" not in cmd
+            and "--allowed-tools" not in cmd
+        ):
+            return cmd
+        # caw emits a single `--mcp-config <path>`; only the first occurrence
+        # is considered.
+        cfg_path = cmd[list(cmd).index("--mcp-config") + 1]
+        with open(cfg_path) as f:
+            servers = list(json.load(f).get("mcpServers", {}).keys())
+        if not servers:
+            return cmd
+        allowed = ",".join(f"mcp__{s}" for s in servers)
+        logger.info("Injected --allowedTools for MCP servers: %s", servers)
+        return list(cmd) + ["--allowedTools", allowed]
+    except Exception as e:  # never break the spawn on a patch hiccup
+        logger.warning("claude allowedTools patch skipped: %s", e)
+        return cmd
 
 
 def _patch_claude_allowed_tools() -> None:
     global _CLAUDE_ALLOWED_PATCH_APPLIED
     if _CLAUDE_ALLOWED_PATCH_APPLIED:
         return
-    import json as _json
-    import subprocess as _sp
+    import subprocess
 
-    _orig_popen = _sp.Popen
+    from caw.providers import claude_code as _caw_claude
 
-    def _popen(cmd, *args, **kwargs):
-        try:
-            if (
-                isinstance(cmd, (list, tuple))
-                and cmd
-                and os.path.basename(str(cmd[0])) == "claude"
-                and "--mcp-config" in cmd
-                and "--allowedTools" not in cmd
-                and "--allowed-tools" not in cmd
-            ):
-                cfg_path = cmd[list(cmd).index("--mcp-config") + 1]
-                servers = list(
-                    _json.load(open(cfg_path)).get("mcpServers", {}).keys()
-                )
-                if servers:
-                    allowed = ",".join(f"mcp__{s}" for s in servers)
-                    cmd = list(cmd) + ["--allowedTools", allowed]
-                    logger.info("Injected --allowedTools for MCP servers: %s", servers)
-        except Exception as e:  # never break the spawn on a patch hiccup
-            logger.warning("claude allowedTools patch skipped: %s", e)
-        return _orig_popen(cmd, *args, **kwargs)
+    class _SubprocessProxy:
+        """``subprocess`` stand-in that rewrites Popen commands.
 
-    _sp.Popen = _popen
+        Every other attribute (PIPE, run, ...) delegates to the real module.
+        """
+
+        @staticmethod
+        def Popen(cmd, *args, **kwargs):
+            return subprocess.Popen(_with_allowed_tools(cmd), *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(subprocess, name)
+
+    _caw_claude.subprocess = _SubprocessProxy()
     _CLAUDE_ALLOWED_PATCH_APPLIED = True
 
 
@@ -185,6 +212,10 @@ class CawBackend(LLMBackend):
         self._caw_provider = _resolve_caw_provider(config.provider)
         # main_model is passed straight through; empty string → caw default.
         self._model: str | None = config.main_model or None
+        # Resolve once, before any agent-run chdir can move the cwd —
+        # os.path.abspath is cwd-relative and _run_module_agent_sync recurses
+        # (via generate_sub_module_documentation) while the cwd is pinned.
+        self._repo_root = str(os.path.abspath(config.repo_path))
 
         # Fail loudly here rather than producing a confusing caw error mid-run.
         cli = _CLI_BINARY[config.provider]
@@ -321,7 +352,7 @@ class CawBackend(LLMBackend):
 
         deps = CodeWikiDeps(
             absolute_docs_path=working_dir,
-            absolute_repo_path=str(os.path.abspath(config.repo_path)),
+            absolute_repo_path=self._repo_root,
             registry={},
             components=components,
             path_to_current_module=list(module_path),
@@ -386,7 +417,7 @@ class CawBackend(LLMBackend):
         if self._caw_provider == "codex":
             run_cwd = working_dir
         else:
-            run_cwd = str(os.path.abspath(config.repo_path))
+            run_cwd = self._repo_root
         try:
             os.chdir(run_cwd)
             try:


### PR DESCRIPTION
## Summary

On the `claude-code` subscription backend, `codewiki generate` can finish with exit 0 and print `✓ Documentation generated successfully!` while actually writing **no markdown** and an **empty `module_tree.json` (`{}`)**. The agent even reports "I've generated comprehensive documentation" — a hallucinated success — because its tool calls were silently denied.

This PR makes subscription mode actually write documentation.

## Reproduction

```bash
codewiki config set --provider claude-code --main-model claude-sonnet-4-6 --cluster-model claude-sonnet-4-6
cd <a small TS/PY repo>
codewiki generate --exclude "node_modules,dist,docs" --github-pages --verbose --output ./docs/codewiki
```

Verbose log shows the agent's tool calls denied:

```
[Tool] mcp__codewiki_tools_XXXXXX__str_replace_editor {"command":"create", ...}
[Result] Claude requested permissions to use mcp__codewiki_tools_XXXXXX__str_replace_editor, but you haven't granted it yet.
[Assistant] I've generated comprehensive documentation...      # <- nothing was written
INFO Module <repo> completed via caw (turns=1, tool_calls=3)
```

Result: `overview.md`/module docs missing, `module_tree.json == {}`, exit 0.

## Root cause

Two issues, both rooted in the claude session **not running in true `bypassPermissions`**.

`caw`'s `ClaudeCodeSession` launches `claude` with `--dangerously-skip-permissions`, which is documented as equivalent to `--permission-mode bypassPermissions`. But **bypass can be disabled by an organization's managed policy**, in which case the flag is **downgraded to `acceptEdits`**. (Confirmed directly: `claude -p --dangerously-skip-permissions` and even `--permission-mode bypassPermissions` reported `permissionMode: acceptEdits` on a managed org account.)

Under `acceptEdits`:

1. **Workspace boundary.** Auto-approval is limited to reads/edits **inside the working directory / additionalDirectories**; paths outside prompt (= denied in non-interactive `-p`). `CawBackend._run_module_agent_sync` `chdir`s into the **output subdir** (needed for codex's native `file_change`), so the source tree in the **parent repo** is out of scope and every source `Read` is denied.
   - docs: https://code.claude.com/docs/en/permission-modes#auto-approve-file-edits-with-acceptedits-mode

2. **MCP-server tools are not auto-approved.** Tools from servers added via `--mcp-config` need an explicit `--allowedTools` under `acceptEdits`; `--dangerously-skip-permissions` alone does not grant them. `caw`'s `ClaudeCodeSession` only ever emits `--disallowedTools`, so CodeWiki's own toolkit (`str_replace_editor`, `read_code_components`, `generate_sub_module_documentation`) is denied.
   - Verified: `claude -p --dangerously-skip-permissions "call mcp tool X"` → **denied**; adding `--allowedTools mcp__server` → **allowed**.
   - docs: https://code.claude.com/docs/en/settings#permission-rule-syntax , https://code.claude.com/docs/en/cli-reference

(The `codex` backend already sidesteps this by mapping to `--dangerously-bypass-approvals-and-sandbox`; the `claude-code` path had no equivalent.)

## Fix

In `codewiki/src/be/caw_backend.py`:

1. For `claude-code`, pin the agent's cwd to the **repo root** instead of the output subdir. `str_replace_editor` writes via an absolute `deps` path, so `--output` is still honored, and the source tree is now inside the workspace. (codex keeps the output-dir cwd for its native `file_change`.)
2. Wrap `subprocess.Popen` so any `claude` command carrying `--mcp-config` also gets `--allowedTools mcp__<server>` for every server in that config. This grants CodeWiki's own toolkit.

## Verification

`confluence-md` (TypeScript, 28 source files), `--provider claude-code`:
- **Before:** no markdown, `module_tree.json == {}`, exit 0 (false success).
- **After:** `overview.md` generated (1275 lines, 11 Mermaid diagrams), 0 permission denials.

## Notes

- Fix #2 (`--allowedTools`) really belongs upstream in `caw`'s `ClaudeCodeSession` (it should allow-list its own toolkit servers, mirroring what it does for codex). The `Popen` wrapper here is a stopgap; happy to move it if you prefer.
- This reproduces specifically when the account/org **disables `bypassPermissions`** (a common enterprise policy). On accounts where `--dangerously-skip-permissions` yields true bypass, the failure may not appear — but the fix is harmless there and makes the tool robust under restricted permission modes.