### PR TITLE
fix(mcp): default get_module_tree output_dir to repo docs path

### DIFF
--- a/codewiki/mcp/server.py
+++ b/codewiki/mcp/server.py
@@ -513,7 +513,12 @@ async def _legacy_generate_docs(arguments: dict[str, Any]) -> list[TextContent]:
 async def _legacy_get_module_tree(arguments: dict[str, Any]) -> list[TextContent]:
     """Legacy get_module_tree."""
     repo_path = Path(arguments["repo_path"]).expanduser().resolve()
-    output_dir = Path(arguments.get("output_dir", "docs")).expanduser().resolve()
+    output_dir_arg = arguments.get("output_dir")
+    if output_dir_arg:
+        output_dir = Path(output_dir_arg).expanduser().resolve()
+    else:
+        # Default docs live next to the repo, not relative to the MCP process cwd.
+        output_dir = (repo_path / "docs").resolve()
 
     module_tree_path = output_dir / "module_tree.json"
     if not module_tree_path.exists():


### PR DESCRIPTION
## Summary

Fixes the default `output_dir` resolution in the legacy `get_module_tree` MCP tool so it looks for `module_tree.json` under the target repository's docs folder instead of the MCP server's current working directory.

## What changed

In `_legacy_get_module_tree`, when `output_dir` is not provided:

- **Before:** defaulted to `Path("docs").resolve()`, which resolved relative to the MCP process cwd
- **After:** defaults to `(repo_path / "docs").resolve()`, so docs are always resolved relative to the analyzed repo

When `output_dir` is explicitly passed, behavior is unchanged — the provided path is still expanded and resolved as before.

## Why

When CodeWiki runs as an MCP server in Cursor (or another IDE), the process cwd is often the workspace root or the MCP install directory, not the repo being analyzed. That caused `get_module_tree` to look in the wrong place (e.g. `./docs/module_tree.json` in the IDE workspace) even when docs had been generated under `<repo>/docs/`.

This aligns the legacy tool with the intended convention that generated docs live next to the repo unless an explicit `output_dir` is given.

## Test plan

- [ ] Call `get_module_tree` with only `repo_path` (no `output_dir`) for a repo that has `<repo>/docs/module_tree.json` — should succeed
- [ ] Call `get_module_tree` from a different cwd (e.g. MCP server started outside the repo) — should still find the module tree
- [ ] Call `get_module_tree` with an explicit `output_dir` — should still use the provided path
- [ ] Call `get_module_tree` when no module tree exists — should return the same clear error as before