### PR TITLE
Partition huge clustering inputs by repo structure; survive empty LLM responses

### DIFF
--- a/codewiki/cli/adapters/doc_generator.py
+++ b/codewiki/cli/adapters/doc_generator.py
@@ -145,6 +145,7 @@ class CLIDocumentationGenerator:
                 max_tokens=self.config.get('max_tokens', 32768),
                 max_token_per_module=self.config.get('max_token_per_module', 36369),
                 max_token_per_leaf_module=self.config.get('max_token_per_leaf_module', 16000),
+                max_leaf_nodes_per_cluster=self.config.get('max_leaf_nodes_per_cluster', 600),
                 max_depth=self.config.get('max_depth', 2),
                 agent_instructions=self.config.get('agent_instructions'),
                 use_gitignore=self.config.get('use_gitignore', True),

--- a/codewiki/src/be/cluster_modules.py
+++ b/codewiki/src/be/cluster_modules.py
@@ -7,11 +7,16 @@ logger = logging.getLogger(__name__)
 
 from codewiki.src.be.dependency_analyzer.models.core import Node
 from codewiki.src.be.llm_services import call_llm
+from codewiki.src.be.module_naming import resolve_unique_name, sanitize_module_name
 from codewiki.src.be.utils import count_tokens
-from codewiki.src.config import Config, DEFAULT_MIN_MODULES_FOR_SUPER_GROUPING
+from codewiki.src.config import (
+    Config,
+    DEFAULT_MAX_LEAF_NODES_PER_CLUSTER,
+    DEFAULT_MIN_MODULES_FOR_SUPER_GROUPING,
+)
 from codewiki.src.be.prompt_template import format_cluster_prompt, format_super_group_prompt
 
-Completer = Callable[[str], str]
+Completer = Callable[[str], Optional[str]]
 
 # When whole-repo mode is chosen but leaf entry points touch fewer than this
 # fraction of parsed files, warn that coverage depends on agent exploration.
@@ -58,6 +63,198 @@ def get_clustering_input_token_count(
     return count_tokens(potential_core_components_with_code)
 
 
+def _cluster_batch_fits(node_ids: List[str], config: Config) -> bool:
+    """Whether a single LLM clustering call can handle these nodes.
+
+    The clustering response must re-emit every component ID verbatim, so the
+    joined ID list is a direct proxy for output size; keep 2x headroom under
+    max_tokens for dict syntax, module names/paths, and preamble.
+    """
+    max_nodes = getattr(
+        config, "max_leaf_nodes_per_cluster", DEFAULT_MAX_LEAF_NODES_PER_CLUSTER
+    )
+    if len(node_ids) > max_nodes:
+        return False
+    output_budget = max(2048, config.max_tokens // 2)
+    return count_tokens("\n".join(node_ids)) <= output_budget
+
+
+def partition_leaf_nodes_by_structure(
+    leaf_nodes: List[str],
+    components: Dict[str, Node],
+    fits: Callable[[List[str]], bool],
+) -> List[List[str]]:
+    """Partition leaf nodes into batches that each satisfy ``fits``.
+
+    Splits along the directory structure of the nodes' relative paths, then
+    greedily coalesces path-adjacent small groups so root-level files and tiny
+    directories don't become their own batches. Deterministic: nodes are
+    processed in (relative_path, id) order. Returns the input as a single
+    batch when it already fits.
+    """
+    valid = []
+    for leaf_node in leaf_nodes:
+        if leaf_node in components:
+            valid.append(leaf_node)
+        else:
+            logger.warning(f"Skipping invalid leaf node '{leaf_node}' - not found in components")
+    valid.sort(key=lambda node: (components[node].relative_path, node))
+    if not valid or fits(valid):
+        return [valid]
+
+    def path_parts(node: str) -> List[str]:
+        return components[node].relative_path.strip("/").split("/")
+
+    def chunk(nodes: List[str]) -> List[List[str]]:
+        # Nodes that share one directory/file and still don't fit can only be
+        # cut into fixed-size slices.
+        size = len(nodes)
+        while size > 1 and not fits(nodes[:size]):
+            size = (size + 1) // 2
+        logger.warning(
+            "Splitting %d leaf nodes that share one path into slices of at "
+            "most %d; directory structure can't divide them further.",
+            len(nodes),
+            size,
+        )
+        return [nodes[i:i + size] for i in range(0, len(nodes), size)]
+
+    def split(nodes: List[str], depth: int) -> List[List[str]]:
+        by_prefix = defaultdict(list)
+        for node in nodes:
+            by_prefix["/".join(path_parts(node)[:depth])].append(node)
+        groups: List[List[str]] = []
+        for prefix in sorted(by_prefix):
+            sub = by_prefix[prefix]
+            if fits(sub):
+                groups.append(sub)
+            elif any(len(path_parts(node)) > depth for node in sub):
+                groups.extend(split(sub, depth + 1))
+            else:
+                groups.extend(chunk(sub))
+        return groups
+
+    batches: List[List[str]] = []
+    current: List[str] = []
+    for group in split(valid, 1):
+        if not current:
+            current = group
+        elif fits(current + group):
+            current.extend(group)
+        else:
+            batches.append(current)
+            current = group
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _cluster_via_llm(
+    leaf_nodes: List[str],
+    components: Dict[str, Node],
+    config: Config,
+    current_module_tree: Dict[str, Any],
+    current_module_name: Optional[str],
+    module_label: str,
+    completer: Optional[Completer],
+) -> Dict[str, Any]:
+    """Run one clustering LLM call over these nodes.
+
+    Returns {} for any empty, malformed, or non-dict response instead of
+    raising, so callers can fall back gracefully.
+    """
+    potential_core_components, _ = format_potential_core_components(leaf_nodes, components)
+    prompt = format_cluster_prompt(potential_core_components, current_module_tree, current_module_name)
+    if completer is not None:
+        response = completer(prompt)
+    else:
+        response = call_llm(prompt, config, model=config.cluster_model)
+
+    if not response:
+        logger.warning(
+            "Empty LLM clustering response for %s (provider returned no "
+            "content, likely output truncation); falling back.",
+            module_label,
+        )
+        return {}
+
+    try:
+        if "<GROUPED_COMPONENTS>" not in response or "</GROUPED_COMPONENTS>" not in response:
+            logger.warning(
+                "Invalid LLM clustering response for %s: missing <GROUPED_COMPONENTS> "
+                "tags; falling back. Response preview: %s...",
+                module_label,
+                str(response)[:200],
+            )
+            return {}
+
+        response_content = response.split("<GROUPED_COMPONENTS>")[1].split("</GROUPED_COMPONENTS>")[0]
+        module_tree = eval(response_content)
+
+        if not isinstance(module_tree, dict):
+            logger.error(f"Invalid module tree format - expected dict, got {type(module_tree)}")
+            return {}
+
+    except Exception as e:
+        logger.warning(
+            "Failed to parse LLM clustering response for %s; falling back. "
+            "Error: %s. Response preview: %s...",
+            module_label,
+            e,
+            str(response)[:200],
+        )
+        logger.error(f"Traceback: {traceback.format_exc()}")
+        return {}
+
+    return module_tree
+
+
+def _merge_module_trees(target: Dict[str, Any], addition: Dict[str, Any]) -> None:
+    """Merge one batch's module dict into the accumulated tree in place.
+
+    Batches cluster independently, so two of them may propose the same module
+    name for the same concept; merge their components rather than renaming
+    (dedupe_module_tree_names still guards anything unexpected later).
+    """
+    for name, info in addition.items():
+        if name not in target:
+            target[name] = info
+            continue
+        existing = target[name]
+        if not isinstance(existing, dict) or not isinstance(info, dict):
+            logger.warning(
+                "Cannot merge module '%s' from another batch; keeping the first version.",
+                name,
+            )
+            continue
+        seen = set(existing.get("components", []))
+        merged = list(existing.get("components", []))
+        for component in info.get("components", []):
+            if component not in seen:
+                seen.add(component)
+                merged.append(component)
+        existing["components"] = merged
+        paths = [existing.get("path", ""), info.get("path", "")]
+        existing["path"] = _common_path_prefix(paths) if all(paths) else ""
+        logger.info(
+            "Module '%s' was produced by multiple clustering batches; merged "
+            "into %d components.",
+            name,
+            len(merged),
+        )
+
+
+def _batch_fallback_name(
+    batch: List[str], components: Dict[str, Node], existing: Dict[str, Any]
+) -> str:
+    """Directory-derived module name for a batch whose LLM clustering failed."""
+    prefix = _common_path_prefix(
+        [components[node].relative_path for node in batch if node in components]
+    )
+    name = sanitize_module_name(prefix.replace("/", "_")) if prefix else "root"
+    return resolve_unique_name(name, None, set(existing))
+
+
 def cluster_modules(
     leaf_nodes: List[str],
     components: Dict[str, Node],
@@ -77,7 +274,7 @@ def cluster_modules(
             subscription-mode (caw) routing.  If ``None``, falls back to
             ``call_llm`` for backward compatibility with direct callers.
     """
-    potential_core_components, potential_core_components_with_code = (
+    _, potential_core_components_with_code = (
         format_potential_core_components(leaf_nodes, components)
     )
     input_tokens = count_tokens(potential_core_components_with_code)
@@ -118,46 +315,68 @@ def cluster_modules(
                 )
         return {}
 
-    prompt = format_cluster_prompt(potential_core_components, current_module_tree, current_module_name)
     logger.info(
         "Requesting LLM module clustering for %s because %d tokens exceed the %d-token threshold.",
         module_label,
         input_tokens,
         threshold,
     )
-    if completer is not None:
-        response = completer(prompt)
-    else:
-        response = call_llm(prompt, config, model=config.cluster_model)
 
-    #parse the response
-    try:
-        if "<GROUPED_COMPONENTS>" not in response or "</GROUPED_COMPONENTS>" not in response:
-            logger.warning(
-                "Invalid LLM clustering response for %s: missing <GROUPED_COMPONENTS> "
-                "tags; falling back to whole-module documentation. Response preview: %s...",
-                module_label,
-                response[:200],
-            )
-            return {}
-        
-        response_content = response.split("<GROUPED_COMPONENTS>")[1].split("</GROUPED_COMPONENTS>")[0]
-        module_tree = eval(response_content)
-        
-        if not isinstance(module_tree, dict):
-            logger.error(f"Invalid module tree format - expected dict, got {type(module_tree)}")
-            return {}
-            
-    except Exception as e:
-        logger.warning(
-            "Failed to parse LLM clustering response for %s; falling back to "
-            "whole-module documentation. Error: %s. Response preview: %s...",
+    batches = partition_leaf_nodes_by_structure(
+        leaf_nodes, components, lambda ids: _cluster_batch_fits(ids, config)
+    )
+
+    if len(batches) == 1:
+        module_tree = _cluster_via_llm(
+            batches[0],
+            components,
+            config,
+            current_module_tree,
+            current_module_name,
             module_label,
-            e,
-            response[:200],
+            completer,
         )
-        logger.error(f"Traceback: {traceback.format_exc()}")
-        return {}
+        if not module_tree:
+            return {}
+    else:
+        logger.info(
+            "Partitioned %d leaf nodes for %s into %d structure-based batches for clustering.",
+            len(leaf_nodes),
+            module_label,
+            len(batches),
+        )
+        module_tree = {}
+        for i, batch in enumerate(batches, 1):
+            batch_label = f"{module_label} (batch {i}/{len(batches)})"
+            # Each batch gets the *unmodified* current_module_tree: passing the
+            # accumulating merge would flip format_cluster_prompt into its
+            # module-level variant mid-partition.
+            partial = _cluster_via_llm(
+                batch,
+                components,
+                config,
+                current_module_tree,
+                current_module_name,
+                batch_label,
+                completer,
+            )
+            if not partial:
+                name = _batch_fallback_name(batch, components, module_tree)
+                partial = {
+                    name: {
+                        "path": _common_path_prefix(
+                            [components[n].relative_path for n in batch if n in components]
+                        ),
+                        "components": list(batch),
+                    }
+                }
+                logger.warning(
+                    "Clustering failed for %s; keeping its %d components as fallback module '%s'.",
+                    batch_label,
+                    len(batch),
+                    name,
+                )
+            _merge_module_trees(module_tree, partial)
 
     # check if the module tree is valid
     if len(module_tree) <= 1:
@@ -182,7 +401,7 @@ def cluster_modules(
         for key in current_module_path:
             value = value[key]["children"]
         for module_name, module_info in module_tree.items():
-            del module_info["path"]
+            module_info.pop("path", None)
             value[module_name] = module_info
 
     for module_name, module_info in module_tree.items():
@@ -226,12 +445,18 @@ def _common_path_prefix(paths: List[str]) -> str:
     return "/".join(common)
 
 
-def _parse_super_group_response(response: str) -> Optional[Dict[str, Any]]:
+def _parse_super_group_response(response: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not response:
+        logger.warning(
+            "Empty super-grouping response (provider returned no content, "
+            "likely output truncation); keeping the flat module tree."
+        )
+        return None
     if "<GROUPED_MODULES>" not in response or "</GROUPED_MODULES>" not in response:
         logger.warning(
             "Invalid super-grouping response: missing <GROUPED_MODULES> tags; "
             "keeping the flat module tree. Response preview: %s...",
-            response[:200],
+            str(response)[:200],
         )
         return None
     try:
@@ -243,7 +468,7 @@ def _parse_super_group_response(response: str) -> Optional[Dict[str, Any]]:
             "Failed to parse super-grouping response; keeping the flat module "
             "tree. Error: %s. Response preview: %s...",
             e,
-            response[:200],
+            str(response)[:200],
         )
         return None
     if not isinstance(grouping, dict):

--- a/codewiki/src/be/documentation_generator.py
+++ b/codewiki/src/be/documentation_generator.py
@@ -287,6 +287,11 @@ class DocumentationGenerator:
         
         try:
             parent_docs = self.backend.complete(prompt)
+            if not parent_docs:
+                raise RuntimeError(
+                    f"LLM returned empty content for {module_name} overview "
+                    f"(possible output truncation at max_tokens)"
+                )
 
             # Parse and save parent documentation. Subscription-CLI backends
             # (claude-code / codex) sometimes ignore the <OVERVIEW> wrapper and

--- a/codewiki/src/be/llm_services.py
+++ b/codewiki/src/be/llm_services.py
@@ -7,6 +7,8 @@ return slightly non-standard responses (e.g. choices[].index = None).
 Supports multiple providers: openai-compatible, anthropic, bedrock, azure-openai.
 """
 import logging
+from typing import Optional
+
 from openai.types import chat
 
 from pydantic_ai.exceptions import ModelHTTPError
@@ -260,11 +262,37 @@ def create_openai_client(config: Config) -> OpenAI:
     )
 
 
+def _extract_content(response, model: str) -> Optional[str]:
+    """Return the message content of *response*, or None if the provider gave none.
+
+    Logs the finish_reason so output truncation (finish_reason == "length",
+    which some proxies pair with ``content: null``) is visible in the logs
+    instead of surfacing later as an opaque NoneType error.
+    """
+    choice = response.choices[0]
+    content = choice.message.content
+    finish_reason = getattr(choice, "finish_reason", None)
+    if finish_reason == "length":
+        logger.warning(
+            "LLM response from %s stopped at the max_tokens limit "
+            "(finish_reason=length); output is truncated%s.",
+            model,
+            " and empty" if not content else "",
+        )
+    if content is None:
+        logger.warning(
+            "LLM returned no content (model=%s, finish_reason=%s); returning None.",
+            model,
+            finish_reason,
+        )
+    return content
+
+
 def call_llm(
     prompt: str,
     config: Config,
     model: str = None
-) -> str:
+) -> Optional[str]:
     """
     Call LLM with the given prompt.
 
@@ -280,7 +308,8 @@ def call_llm(
         model: Model name (defaults to config.main_model)
 
     Returns:
-        LLM response text
+        LLM response text, or None when the provider returned no content
+        (e.g. output truncated at max_tokens before any text was emitted).
     """
     if model is None:
         model = config.main_model
@@ -324,7 +353,7 @@ def call_llm(
             )
         else:
             raise
-    return response.choices[0].message.content
+    return _extract_content(response, model)
 
 
 def _is_unsupported_token_param_error(err: BadRequestError, param: str) -> bool:
@@ -344,7 +373,7 @@ def _call_llm_via_litellm(
     prompt: str,
     config: Config,
     model: str
-) -> str:
+) -> Optional[str]:
     """
     Call LLM via litellm for Bedrock/Anthropic providers.
 
@@ -368,14 +397,14 @@ def _call_llm_via_litellm(
         max_tokens=config.max_tokens,
         api_key=config.llm_api_key if config.provider != "bedrock" else None,
     )
-    return response.choices[0].message.content
+    return _extract_content(response, litellm_model)
 
 
 def _call_llm_via_azure(
     prompt: str,
     config: Config,
     model: str
-) -> str:
+) -> Optional[str]:
     """
     Call LLM via Azure OpenAI.
 
@@ -398,4 +427,4 @@ def _call_llm_via_azure(
         messages=[{"role": "user", "content": prompt}],
         max_tokens=config.max_tokens,
     )
-    return response.choices[0].message.content
+    return _extract_content(response, deployment)

--- a/codewiki/src/config.py
+++ b/codewiki/src/config.py
@@ -21,6 +21,11 @@ DEFAULT_MAX_TOKEN_PER_LEAF_MODULE = 4_000
 # Super-group the flat top level into architectural subsystems only when it
 # has more than this many modules; 0 or negative disables the pass.
 DEFAULT_MIN_MODULES_FOR_SUPER_GROUPING = 3
+# A single clustering call must re-emit every component ID in its output, so
+# huge inputs are partitioned by directory structure into batches of at most
+# this many leaf nodes (and further bounded by an output-token budget derived
+# from max_tokens).
+DEFAULT_MAX_LEAF_NODES_PER_CLUSTER = 600
 # Legacy constants (for backward compatibility)
 MAX_TOKEN_PER_MODULE = DEFAULT_MAX_TOKEN_PER_MODULE
 MAX_TOKEN_PER_LEAF_MODULE = DEFAULT_MAX_TOKEN_PER_LEAF_MODULE
@@ -74,6 +79,7 @@ class Config:
     max_token_per_module: int = DEFAULT_MAX_TOKEN_PER_MODULE
     max_token_per_leaf_module: int = DEFAULT_MAX_TOKEN_PER_LEAF_MODULE
     min_modules_for_super_grouping: int = DEFAULT_MIN_MODULES_FOR_SUPER_GROUPING
+    max_leaf_nodes_per_cluster: int = DEFAULT_MAX_LEAF_NODES_PER_CLUSTER
     # Prompt caching for agentic/multi-turn calls (auto-disables per model if
     # the provider rejects cache_control markers)
     prompt_caching: bool = True
@@ -182,6 +188,7 @@ class Config:
         max_token_per_module: int = DEFAULT_MAX_TOKEN_PER_MODULE,
         max_token_per_leaf_module: int = DEFAULT_MAX_TOKEN_PER_LEAF_MODULE,
         min_modules_for_super_grouping: int = DEFAULT_MIN_MODULES_FOR_SUPER_GROUPING,
+        max_leaf_nodes_per_cluster: int = DEFAULT_MAX_LEAF_NODES_PER_CLUSTER,
         max_depth: int = MAX_DEPTH,
         agent_instructions: Optional[Dict[str, Any]] = None,
         use_gitignore: bool = True,
@@ -208,6 +215,8 @@ class Config:
             min_modules_for_super_grouping: Super-group the top level into
                 subsystems only when it has more than this many modules
                 (0 or negative disables the pass)
+            max_leaf_nodes_per_cluster: Partition clustering inputs into
+                structure-based batches of at most this many leaf nodes
             max_depth: Maximum depth for hierarchical decomposition
             agent_instructions: Custom agent instructions dict
             use_gitignore: Whether to apply Git ignore rules
@@ -238,6 +247,7 @@ class Config:
             max_token_per_module=max_token_per_module,
             max_token_per_leaf_module=max_token_per_leaf_module,
             min_modules_for_super_grouping=min_modules_for_super_grouping,
+            max_leaf_nodes_per_cluster=max_leaf_nodes_per_cluster,
             agent_instructions=agent_instructions,
             use_gitignore=use_gitignore,
             prompt_caching=prompt_caching,

--- a/tests/test_cluster_partitioning.py
+++ b/tests/test_cluster_partitioning.py
@@ -1,0 +1,266 @@
+"""Tests for structure-based clustering batches and None-robust LLM handling.
+
+Covers partition_leaf_nodes_by_structure (directory splitting, chunking of
+unsplittable groups, coalescing, determinism), the batched cluster_modules
+flow (flat merge, name-collision union, per-batch fallback), and the guards
+that turn an empty/None LLM response into a graceful fallback instead of a
+TypeError (issue seen on the electron run: output truncated at max_tokens,
+provider returned content: null).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from codewiki.src.be.cluster_modules import (
+    _batch_fallback_name,
+    _cluster_batch_fits,
+    _merge_module_trees,
+    _parse_super_group_response,
+    cluster_modules,
+    partition_leaf_nodes_by_structure,
+    super_group_modules,
+)
+from codewiki.src.be.dependency_analyzer.models.core import Node
+from codewiki.src.be.llm_services import _extract_content
+from codewiki.src.config import Config
+
+
+def _make_node(component_id: str, source_code: str = "code") -> Node:
+    rel_path, _, name = component_id.partition("::")
+    return Node(
+        id=component_id,
+        name=name or component_id,
+        component_type="class",
+        file_path=rel_path,
+        relative_path=rel_path,
+        source_code=source_code,
+    )
+
+
+def _components(component_ids: list[str]) -> dict[str, Node]:
+    return {cid: _make_node(cid) for cid in component_ids}
+
+
+def _config(**overrides) -> Config:
+    kwargs = dict(
+        repo_path="/tmp/repo",
+        output_dir="/tmp/out",
+        llm_base_url="http://localhost",
+        llm_api_key="key",
+        main_model="m",
+        cluster_model="m",
+    )
+    return Config.from_cli(**kwargs, **overrides)
+
+
+def _max_count_fits(limit: int):
+    """A fits() predicate on node count only — keeps tests tokenizer-free."""
+    return lambda ids: len(ids) <= limit
+
+
+# ---------------------------------------------------------------------------
+# partition_leaf_nodes_by_structure
+# ---------------------------------------------------------------------------
+
+def test_partition_single_batch_when_everything_fits():
+    ids = [f"lib/a.py::C{i}" for i in range(5)]
+    components = _components(ids)
+    batches = partition_leaf_nodes_by_structure(ids, components, _max_count_fits(10))
+    assert batches == [sorted(ids)]
+
+
+def test_partition_drops_unknown_ids():
+    ids = ["lib/a.py::A", "lib/b.py::B"]
+    components = _components(ids)
+    batches = partition_leaf_nodes_by_structure(
+        ids + ["gone/x.py::X"], components, _max_count_fits(10)
+    )
+    assert batches == [ids]
+
+
+def test_partition_splits_by_top_level_directory():
+    ids = [f"alpha/f{i}.py::A{i}" for i in range(4)] + [
+        f"beta/f{i}.py::B{i}" for i in range(4)
+    ]
+    components = _components(ids)
+    batches = partition_leaf_nodes_by_structure(ids, components, _max_count_fits(4))
+    assert len(batches) == 2
+    assert all(len(batch) == 4 for batch in batches)
+    # Path-sorted: alpha before beta.
+    assert all(cid.startswith("alpha/") for cid in batches[0])
+    assert all(cid.startswith("beta/") for cid in batches[1])
+
+
+def test_partition_recurses_into_oversized_directory():
+    ids = [f"pkg/sub{i // 3}/f{i}.py::C{i}" for i in range(9)]
+    components = _components(ids)
+    batches = partition_leaf_nodes_by_structure(ids, components, _max_count_fits(3))
+    assert all(len(batch) <= 3 for batch in batches)
+    union = sorted(cid for batch in batches for cid in batch)
+    assert union == sorted(ids)
+
+
+def test_partition_chunks_unsplittable_single_file():
+    ids = [f"one/file.py::C{i:02d}" for i in range(10)]
+    components = _components(ids)
+    batches = partition_leaf_nodes_by_structure(ids, components, _max_count_fits(4))
+    assert all(len(batch) <= 4 for batch in batches)
+    union = [cid for batch in batches for cid in batch]
+    assert sorted(union) == sorted(ids)
+
+
+def test_partition_coalesces_root_files_and_is_deterministic():
+    ids = (
+        ["setup.py::Setup", "conftest.py::Conf"]
+        + [f"src/f{i}.py::S{i}" for i in range(3)]
+    )
+    components = _components(ids)
+    first = partition_leaf_nodes_by_structure(ids, components, _max_count_fits(4))
+    second = partition_leaf_nodes_by_structure(
+        list(reversed(ids)), components, _max_count_fits(4)
+    )
+    assert first == second
+    assert all(len(batch) <= 4 for batch in first)
+    # Root-level files must not sit alone in single-node batches.
+    assert all(len(batch) > 1 for batch in first)
+    union = sorted(cid for batch in first for cid in batch)
+    assert union == sorted(ids)
+
+
+def test_cluster_batch_fits_respects_node_count_and_token_budget():
+    config = _config(max_leaf_nodes_per_cluster=2, max_tokens=64000)
+    assert _cluster_batch_fits(["a/b.py::X"], config)
+    assert not _cluster_batch_fits(["a/b.py::X", "a/c.py::Y", "a/d.py::Z"], config)
+    # Tiny max_tokens shrinks the output budget below even a few IDs.
+    tight = _config(max_leaf_nodes_per_cluster=600, max_tokens=1)
+    long_ids = ["dir/" + "verylongsegment" * 400 + f".py::C{i}" for i in range(3)]
+    assert not _cluster_batch_fits(long_ids, tight)
+
+
+# ---------------------------------------------------------------------------
+# None-robustness
+# ---------------------------------------------------------------------------
+
+def test_cluster_modules_none_response_returns_empty_tree():
+    ids = [f"lib/f{i}.py::C{i}" for i in range(3)]
+    components = _components(ids)
+    config = _config(max_token_per_module=1)
+    result = cluster_modules(
+        ids, components, config, {}, None, [], completer=lambda prompt: None
+    )
+    assert result == {}
+
+
+def test_parse_super_group_response_handles_none_and_garbage():
+    assert _parse_super_group_response(None) is None
+    assert _parse_super_group_response("") is None
+    assert _parse_super_group_response("no tags here") is None
+
+
+def test_super_group_modules_none_response_keeps_tree():
+    tree = {
+        f"Module{i}": {"path": f"m{i}", "components": [f"m{i}/f.py::C"]}
+        for i in range(5)
+    }
+    config = _config()
+    assert super_group_modules(tree, config, completer=lambda prompt: None) == tree
+
+
+def test_extract_content_returns_none_on_truncated_empty_response():
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=None), finish_reason="length"
+            )
+        ]
+    )
+    assert _extract_content(response, "test-model") is None
+    ok = SimpleNamespace(
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content="hi"), finish_reason="stop")
+        ]
+    )
+    assert _extract_content(ok, "test-model") == "hi"
+
+
+# ---------------------------------------------------------------------------
+# Batched clustering end-to-end (scripted completer)
+# ---------------------------------------------------------------------------
+
+def _grouped(tree: dict) -> str:
+    return f"<GROUPED_COMPONENTS>{tree!r}</GROUPED_COMPONENTS>"
+
+
+def test_batched_clustering_merges_batches_and_collisions():
+    alpha = [f"alpha/f{i}.py::A{i}" for i in range(3)]
+    beta = [f"beta/f{i}.py::B{i}" for i in range(3)]
+    components = _components(alpha + beta)
+    config = _config(max_token_per_module=1, max_leaf_nodes_per_cluster=3)
+
+    def completer(prompt: str) -> str:
+        if "<MODULE_TREE>" in prompt:
+            return None  # recursive module-level calls: decline so recursion stops
+        in_alpha = alpha[0] in prompt
+        in_beta = beta[0] in prompt
+        if in_alpha and not in_beta:
+            return _grouped({
+                "Alpha": {"path": "alpha", "components": alpha[:2]},
+                "Shared": {"path": "alpha", "components": [alpha[2]]},
+            })
+        if in_beta and not in_alpha:
+            return _grouped({
+                "Beta": {"path": "beta", "components": beta[:2]},
+                "Shared": {"path": "beta", "components": [beta[2]]},
+            })
+        return None
+
+    tree = cluster_modules(
+        alpha + beta, components, config, {}, None, [], completer=completer
+    )
+    assert set(tree) == {"Alpha", "Shared", "Beta"}
+    # Name collision across batches merges components and generalizes the path.
+    assert tree["Shared"]["components"] == [alpha[2], beta[2]]
+    assert tree["Shared"]["path"] == ""
+    assert tree["Alpha"]["components"] == alpha[:2]
+
+
+def test_batched_clustering_failed_batch_becomes_fallback_module():
+    alpha = [f"alpha/f{i}.py::A{i}" for i in range(3)]
+    beta = [f"beta/f{i}.py::B{i}" for i in range(3)]
+    components = _components(alpha + beta)
+    config = _config(max_token_per_module=1, max_leaf_nodes_per_cluster=3)
+
+    def completer(prompt: str) -> str:
+        if "<MODULE_TREE>" in prompt:
+            return None  # recursive module-level calls: decline so recursion stops
+        if beta[0] in prompt and alpha[0] not in prompt:
+            return None  # this batch's call "truncates"
+        if alpha[0] in prompt and beta[0] not in prompt:
+            return _grouped({
+                "Alpha": {"path": "alpha", "components": alpha[:2]},
+                "AlphaExtra": {"path": "alpha", "components": [alpha[2]]},
+            })
+        return None
+
+    tree = cluster_modules(
+        alpha + beta, components, config, {}, None, [], completer=completer
+    )
+    assert "Alpha" in tree and "AlphaExtra" in tree
+    fallback = tree["beta"]
+    assert fallback["components"] == beta
+    assert fallback["path"] == "beta"
+
+
+def test_merge_module_trees_and_fallback_name_helpers():
+    target = {"M": {"path": "a/b", "components": ["a/b/x.py::X"]}}
+    _merge_module_trees(
+        target, {"M": {"path": "a/c", "components": ["a/c/y.py::Y", "a/b/x.py::X"]}}
+    )
+    assert target["M"]["components"] == ["a/b/x.py::X", "a/c/y.py::Y"]
+    assert target["M"]["path"] == "a"
+
+    ids = ["pkg/mod/f.py::A", "pkg/mod/g.py::B"]
+    components = _components(ids)
+    assert _batch_fallback_name(ids, components, {}) == "pkg_mod"
+    assert _batch_fallback_name(ids, components, {"pkg_mod": {}}) == "pkg_mod_2"


### PR DESCRIPTION
## Problem

On large repos, module clustering sends every leaf-node ID in a single LLM call and requires the model to re-emit each ID verbatim in the grouped output. On electron (7733 parsed files, **1085 leaf nodes**), the required output exceeded `max_tokens` (16384): the response truncated with `finish_reason=length`, the provider returned `content: null`, and generation aborted:

```
✗ Module clustering failed: 'NoneType' object is not subscriptable
```

Two stacked issues:
1. `call_llm` returns `response.choices[0].message.content` unchecked, so a truncated-empty response surfaces as `None`.
2. `cluster_modules` crashes on that `None` twice — the `<GROUPED_COMPONENTS>` tag check, then `response[:200]` inside its own `except` handler — so the intended graceful fallback never runs and the whole job dies.

## Fix

**Structure-based batching (main change).** When one clustering call can't handle the input, `cluster_modules` now partitions leaf nodes along the directory structure of their `relative_path` into batches, clusters each batch separately, and merges the results into one flat top level. The existing `super_group_modules` pass then consolidates them into subsystems, so the final tree keeps its normal LLM-named shape — batches are invisible in the output.

- A batch fits when it has at most `max_leaf_nodes_per_cluster` nodes (new config knob, default 600) **and** its joined IDs fit in an output budget of `max_tokens // 2` (the output must re-emit every ID, so the ID list is a direct proxy for output size).
- Oversized directories split recursively; nodes sharing a single path that still don't fit are chunked with a warning; path-adjacent small groups (root-level files, tiny dirs) coalesce greedily. Deterministic ordering throughout.
- Same-named modules from different batches merge their components (path becomes the common prefix); `dedupe_module_tree_names` still runs afterwards as the safety net.
- A batch whose call fails degrades to a directory-named fallback module instead of losing its nodes; the recursion then tries to cluster it further.
- The guard applies at every recursion level automatically, since partitioning happens inside `cluster_modules` before each LLM call.

**None/truncation robustness.** New `_extract_content` helper in `llm_services` logs `finish_reason=length` truncation and passes `None` through explicitly; `cluster_modules`, `_parse_super_group_response`, and the overview generation in `documentation_generator` now treat an empty/`None` response as a graceful fallback instead of a `TypeError`.

## Validation

- 14 new tests in `tests/test_cluster_partitioning.py` (partitioner splitting/chunking/coalescing/determinism, batched end-to-end merge with scripted completers, name-collision union, failed-batch fallback, `None`-response paths). Full suite: 41 passed.
- Dry run against the real electron dependency graph: the 1085 leaf nodes partition into 2 batches (588 + 497 nodes, ~8k output tokens of IDs each), all nodes covered, no loss.