### PR TITLE
fix: make CachingOpenAIModel._map_messages version-adaptive

### DIFF
--- a/codewiki/src/be/llm_services.py
+++ b/codewiki/src/be/llm_services.py
@@ -152,12 +152,16 @@ class CachingOpenAIModel(CompatibleOpenAIModel):
     async def _map_messages(self, messages, model_request_parameters=None, *, model_settings=None):
         base = OpenAIChatModel._map_messages
         base_params = set(inspect.signature(base).parameters)
-        if "model_request_parameters" in base_params:
+        if "model_settings" in base_params:
             openai_messages = await super()._map_messages(
                 messages, model_request_parameters, model_settings=model_settings
             )
+        elif "model_request_parameters" in base_params:
+            # Intermediate pydantic-ai versions accept request parameters but
+            # predate the keyword-only model_settings argument.
+            openai_messages = await super()._map_messages(messages, model_request_parameters)
         else:
-            # pydantic-ai < 1.107: base _map_messages accepts only messages.
+            # Early pydantic-ai versions accept only messages.
             openai_messages = await super()._map_messages(messages)
         if self._prompt_caching_active:
             # Breakpoint 1: last system/developer message (covers tools + system).

--- a/codewiki/src/be/llm_services.py
+++ b/codewiki/src/be/llm_services.py
@@ -6,6 +6,7 @@ return slightly non-standard responses (e.g. choices[].index = None).
 
 Supports multiple providers: openai-compatible, anthropic, bedrock, azure-openai.
 """
+import inspect
 import logging
 from typing import Optional
 
@@ -148,10 +149,16 @@ class CachingOpenAIModel(CompatibleOpenAIModel):
     def _prompt_caching_active(self) -> bool:
         return self._prompt_caching_enabled and self._cache_registry_key not in _CACHE_UNSUPPORTED
 
-    async def _map_messages(self, messages, model_request_parameters, *, model_settings=None):
-        openai_messages = await super()._map_messages(
-            messages, model_request_parameters, model_settings=model_settings
-        )
+    async def _map_messages(self, messages, model_request_parameters=None, *, model_settings=None):
+        base = OpenAIChatModel._map_messages
+        base_params = set(inspect.signature(base).parameters)
+        if "model_request_parameters" in base_params:
+            openai_messages = await super()._map_messages(
+                messages, model_request_parameters, model_settings=model_settings
+            )
+        else:
+            # pydantic-ai < 1.107: base _map_messages accepts only messages.
+            openai_messages = await super()._map_messages(messages)
         if self._prompt_caching_active:
             # Breakpoint 1: last system/developer message (covers tools + system).
             for message in reversed(openai_messages):

--- a/tests/test_prompt_caching.py
+++ b/tests/test_prompt_caching.py
@@ -57,6 +57,50 @@ def _map(model: CachingOpenAIModel) -> list:
     )
 
 
+def test_map_messages_adapts_to_all_base_signatures():
+    """Forward only the arguments supported by each pydantic-ai API era."""
+    model = _make_model(prompt_caching=False)
+    history = _history()
+    request_parameters = ModelRequestParameters()
+    model_settings = {"temperature": 0}
+    calls = []
+
+    async def one_argument(self, messages):
+        calls.append(("one", messages))
+        return []
+
+    async def two_arguments(self, messages, model_request_parameters):
+        calls.append(("two", messages, model_request_parameters))
+        return []
+
+    async def three_arguments(
+        self, messages, model_request_parameters, *, model_settings=None
+    ):
+        calls.append(("three", messages, model_request_parameters, model_settings))
+        return []
+
+    original = OpenAIChatModel._map_messages
+    try:
+        for base_method in (one_argument, two_arguments, three_arguments):
+            OpenAIChatModel._map_messages = base_method
+            result = asyncio.run(
+                model._map_messages(
+                    history,
+                    request_parameters,
+                    model_settings=model_settings,
+                )
+            )
+            assert result == []
+    finally:
+        OpenAIChatModel._map_messages = original
+
+    assert calls == [
+        ("one", history),
+        ("two", history, request_parameters),
+        ("three", history, request_parameters, model_settings),
+    ]
+
+
 def test_injects_breakpoints_on_system_and_final_message():
     _CACHE_UNSUPPORTED.clear()
     messages = _map(_make_model())


### PR DESCRIPTION
Fixes the 4 failing tests in `tests/test_prompt_caching.py` with a minimal code-only change — **no dependency changes**.

## Root cause
`CachingOpenAIModel._map_messages` (codewiki/src/be/llm_services.py) unconditionally forwarded `model_request_parameters` and `model_settings` to `super()._map_messages(...)`, but the pinned `pydantic-ai==1.0.6` base `OpenAIChatModel._map_messages` accepts only `messages` (the 3-argument signature only exists in `>=1.107`). Every call raised:

```
TypeError: OpenAIChatModel._map_messages() got an unexpected keyword argument 'model_settings'
```

## Fix
- Inspect the base `_map_messages` signature and forward the matching argument set: 3 args on `>=1.107`, 1 arg on `1.0.6`.
- Default `model_request_parameters=None` so pydantic-ai 1.0.6's internal one-argument `self._map_messages(messages)` call inside `_completions_create` also works.

## Verification
- `pytest -p no:cacheprovider -o addopts="" tests/ -q` → **41 passed, 0 failed** (was 4 failed / 37 passed).
- No changes to `requirements.txt` or `pyproject.toml`.