### PR TITLE
ci: add GitHub Actions workflow (test + lint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,27 @@ jobs:
       - name: Install ruff
         run: pip install ruff
 
+      - name: Collect changed Python files
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            diff_range="${PR_BASE_SHA}...${PR_HEAD_SHA}"
+          else
+            diff_range="${PUSH_BASE_SHA}..${GITHUB_SHA}"
+          fi
+
+          git diff --name-only --diff-filter=ACMR -z "$diff_range" -- '*.py' \
+            > "$RUNNER_TEMP/changed-python-files"
+
       - name: Ruff check changed files
         run: |
-          git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- '*.py' \
-            | xargs -r ruff check --output-format=github
+          xargs -0 -r ruff check --output-format=github \
+            < "$RUNNER_TEMP/changed-python-files"
 
       - name: Ruff format check changed files
         run: |
-          git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- '*.py' \
-            | xargs -r ruff format --check
+          xargs -0 -r ruff format --check \
+            < "$RUNNER_TEMP/changed-python-files"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio pytest-cov ruff
+          pip install -e . --no-deps
+
+      - name: Run tests
+        run: pytest -p no:cacheprovider -o addopts="" tests/ -q
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Ruff check changed files
+        run: |
+          git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- '*.py' \
+            | xargs -r ruff check --output-format=github
+
+      - name: Ruff format check changed files
+        run: |
+          git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- '*.py' \
+            | xargs -r ruff format --check


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` with two blocking jobs on PRs to `main` and pushes to `main`:

- **test**: installs the pinned `requirements.txt` (deterministic on pydantic-ai 1.0.6) + dev tools, installs the package with `--no-deps` so pip never re-resolves dependency floors, runs `pytest`.
- **lint**: runs `ruff check` (github-format annotations) and `ruff format --check` on only the `.py` files changed in the PR, so pre-existing repo-wide debt never blocks unrelated PRs.

Validated via a fork-internal test run ([LiberiFatali/CodeWiki#1](https://github.com/LiberiFatali/CodeWiki/pull/1)).

Note: the 4 `test_prompt_caching.py` failures in the test job are expected until #87 (the version-adaptive `_map_messages` fix) merges; they resolve automatically once this branch is rebased on top of it.