### PR TITLE
feat: add OrcaRouter as a first-class provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ codewiki --version
 
 ### 2. Configure Your Environment
 
-CodeWiki supports multiple LLM providers: **OpenAI-compatible**, **Atlas Cloud**, **Anthropic**, **AWS Bedrock**, **Azure OpenAI**, plus subscription mode via **Claude Code** and **Codex** CLIs (no API key required).
+CodeWiki supports multiple LLM providers: **OpenAI-compatible**, **Atlas Cloud**, **OrcaRouter**, **Anthropic**, **AWS Bedrock**, **Azure OpenAI**, plus subscription mode via **Claude Code** and **Codex** CLIs (no API key required).
 
 ```bash
 # OpenAI-compatible
@@ -67,6 +67,14 @@ codewiki config set \
   --main-model anthropic/claude-sonnet-4.6 \
   --cluster-model anthropic/claude-sonnet-4.6 \
   --fallback-model zai-org/GLM-4.6
+
+# OrcaRouter — base URL auto-set to https://api.orcarouter.ai/v1;
+# API key read from $ORCAROUTER_API_KEY when --api-key is omitted.
+codewiki config set \
+  --provider orcarouter \
+  --main-model anthropic/claude-sonnet-5 \
+  --cluster-model anthropic/claude-sonnet-5 \
+  --fallback-model z-ai/glm-4.6
 
 # Anthropic
 codewiki config set \
@@ -109,6 +117,8 @@ codewiki config set \
 ```
 
 **About Atlas Cloud.** [Atlas Cloud](https://www.atlascloud.ai) is a full-modal AI inference platform that exposes LLM, image, and video models (300+) behind a single OpenAI-compatible API, so it works with CodeWiki out of the box. Browse model IDs at the [models endpoint](https://api.atlascloud.ai/v1/models) and pick a strong coding model for `--main-model` / `--cluster-model`; their [coding plan](https://www.atlascloud.ai/console/coding-plan) offers budget-friendly API access.
+
+**About OrcaRouter.** [OrcaRouter](https://www.orcarouter.ai) is a fast, cost-aware AI gateway that routes every call through OpenAI- and Anthropic-compatible endpoints, so it works with CodeWiki out of the box. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Browse model IDs at the [models endpoint](https://api.orcarouter.ai/v1/models) and pick a strong coding model for `--main-model` / `--cluster-model`.
 
 **Subscription mode** routes every LLM call through the local `claude` / `codex` CLI binary (via the [`caw`](https://github.com/zzjas/caw) library), so you can run CodeWiki on a Claude Pro/Max or Codex subscription instead of paying per-token API usage. Claude Code's built-in `Write`/`Edit`/`Bash` tools are disabled inside CodeWiki's agent loop so documentation writes still go through CodeWiki's Mermaid-validating editor.
 

--- a/codewiki/cli/commands/config.py
+++ b/codewiki/cli/commands/config.py
@@ -87,12 +87,13 @@ def config_group():
 @click.option(
     "--provider",
     type=click.Choice(
-        ['openai-compatible', 'atlas-cloud', 'anthropic', 'bedrock', 'azure-openai', 'claude-code', 'codex'],
+        ['openai-compatible', 'atlas-cloud', 'orcarouter', 'anthropic', 'bedrock', 'azure-openai', 'claude-code', 'codex'],
         case_sensitive=False,
     ),
     help=(
         "LLM provider type (default: openai-compatible). "
         "Use 'atlas-cloud' for Atlas Cloud (base URL auto-set; reads ATLASCLOUD_API_KEY). "
+        "Use 'orcarouter' for OrcaRouter (base URL auto-set; reads ORCAROUTER_API_KEY). "
         "Use 'claude-code' or 'codex' to run on a CLI subscription instead of an API key."
     ),
 )
@@ -160,6 +161,11 @@ def config_set(
     $ codewiki config set --provider atlas-cloud --main-model <atlas-model> --cluster-model <atlas-model>
 
     \b
+    # OrcaRouter (OpenAI-compatible) — base URL auto-set,
+    # API key read from ORCAROUTER_API_KEY if --api-key is omitted
+    $ codewiki config set --provider orcarouter --main-model <model> --cluster-model <model>
+
+    \b
     # Subscription mode (Claude Code) — no API key needed,
     # authenticate via 'claude login' on the host first
     $ codewiki config set --provider claude-code --main-model claude-sonnet-4-5
@@ -203,6 +209,16 @@ def config_set(
                 base_url = ATLAS_CLOUD_BASE_URL
             if not api_key:
                 api_key = os.getenv("ATLASCLOUD_API_KEY")
+
+        # OrcaRouter convenience defaults: it's an OpenAI-compatible endpoint, so
+        # auto-fill its base URL and pull the API key from ORCAROUTER_API_KEY when
+        # the user does not pass them explicitly.
+        if provider and provider.lower() == "orcarouter":
+            from codewiki.src.config import ORCAROUTER_BASE_URL
+            if not base_url:
+                base_url = ORCAROUTER_BASE_URL
+            if not api_key:
+                api_key = os.getenv("ORCAROUTER_API_KEY")
 
         # Validate inputs before saving
         validated_data = {}

--- a/codewiki/cli/models/config.py
+++ b/codewiki/cli/models/config.py
@@ -113,7 +113,7 @@ class Configuration:
         cluster_model: Model for module clustering
         fallback_model: Fallback model for documentation generation
         default_output: Default output directory
-        provider: LLM provider type (openai-compatible, atlas-cloud, anthropic, bedrock, azure-openai)
+        provider: LLM provider type (openai-compatible, atlas-cloud, orcarouter, anthropic, bedrock, azure-openai)
         aws_region: AWS region for Bedrock provider
         api_version: Azure OpenAI API version
         azure_deployment: Azure OpenAI deployment name

--- a/codewiki/src/config.py
+++ b/codewiki/src/config.py
@@ -55,6 +55,10 @@ LLM_API_KEY = os.getenv('LLM_API_KEY', 'sk-1234')
 # when the user selects the `atlas-cloud` provider without passing --base-url.
 ATLAS_CLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
 
+# OrcaRouter default endpoint (OpenAI-compatible). Used to auto-fill the base URL
+# when the user selects the `orcarouter` provider without passing --base-url.
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
 @dataclass
 class Config:
     """Configuration class for CodeWiki."""
@@ -70,7 +74,7 @@ class Config:
     cluster_model: str
     fallback_model: str = FALLBACK_MODEL_1
     # Provider configuration
-    provider: str = "openai-compatible"  # openai-compatible, atlas-cloud, anthropic, bedrock, azure-openai
+    provider: str = "openai-compatible"  # openai-compatible, atlas-cloud, orcarouter, anthropic, bedrock, azure-openai
     aws_region: str = "us-east-1"
     api_version: str = "2024-12-01-preview"  # Azure OpenAI API version
     azure_deployment: str = ""  # Azure OpenAI deployment name
@@ -205,7 +209,7 @@ class Config:
             main_model: Primary model
             cluster_model: Clustering model
             fallback_model: Fallback model
-            provider: LLM provider type (openai-compatible, atlas-cloud, anthropic, bedrock, azure-openai)
+            provider: LLM provider type (openai-compatible, atlas-cloud, orcarouter, anthropic, bedrock, azure-openai)
             aws_region: AWS region for Bedrock provider
             api_version: Azure OpenAI API version
             azure_deployment: Azure OpenAI deployment name


### PR DESCRIPTION
## What

Adds **OrcaRouter** as a first-class `--provider` option in `codewiki config set`, so CodeWiki can run through the [OrcaRouter](https://www.orcarouter.ai) AI gateway out of the box.

Selecting `--provider orcarouter` auto-fills the base URL (`https://api.orcarouter.ai/v1`) and reads the API key from `ORCAROUTER_API_KEY` when `--api-key` is omitted — mirroring the existing `atlas-cloud` convenience path. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `codewiki/src/config.py`: add `ORCAROUTER_BASE_URL` constant; document `orcarouter` in `Config` docstrings
- `codewiki/cli/commands/config.py`: add `orcarouter` to the provider `click.Choice`, help text, docstring example, and base-URL/API-key auto-fill block
- `codewiki/cli/models/config.py`: document `orcarouter` in the `Configuration.provider` docstring
- `README.md`: add OrcaRouter to the supported-provider list, config example, and an "About OrcaRouter" note

## Verified

- `codewiki config set --provider orcarouter` auto-sets base URL and reads `ORCAROUTER_API_KEY`
- `codewiki config validate --verbose` connects to the live endpoint (`https://api.orcarouter.ai/v1`) successfully
- `pytest tests/` — 40 passed; 2 pre-existing Windows path-separator failures in `test_gitignore_filtering.py` (unrelated; pass on Linux CI)
- `ruff check` on changed files reports only pre-existing issues already present on `main`

I'm an engineer on the OrcaRouter team.