### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,11 +452,11 @@ If you use CodeWiki in your research, please cite:
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#FSoft-AI4Code/CodeWiki&Date">
+  <a href="https://star-history.dera.page/#FSoft-AI4Code/CodeWiki&type=Date">
    <picture>
-     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=FSoft-AI4Code/CodeWiki&type=Date&theme=dark" />
-     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=FSoft-AI4Code/CodeWiki&type=Date" />
-     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=FSoft-AI4Code/CodeWiki&type=Date" />
+     <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=FSoft-AI4Code/CodeWiki&type=Date&theme=dark" />
+     <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=FSoft-AI4Code/CodeWiki&type=Date" />
+     <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=FSoft-AI4Code/CodeWiki&type=Date" />
    </picture>
   </a>
 </p>


### PR DESCRIPTION
The star history chart in the README is currently broken, which means an important part of the project's public-facing documentation no longer renders for visitors. This change swaps the chart over to a working source so the star history displays correctly again.