### PR TITLE
Add SECURITY.md and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 FSoft-AI4Code
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not report security issues through public GitHub issues, pull
+requests, or discussions.
+
+Use GitHub's private vulnerability reporting instead:
+
+**https://github.com/FSoft-AI4Code/CodeWiki/security/advisories/new**
+
+This opens a private thread that only the CodeWiki maintainers can see. You do
+not need to be a collaborator on the repository to use it.
+
+When reporting, please include as much of the following as you can:
+
+- The version or commit of CodeWiki you tested against
+- The command line or configuration you used (redact any API keys)
+- Steps to reproduce, or a minimal repository that triggers the issue
+- What an attacker can achieve, and under which conditions
+- Any suggested fix, if you have one
+
+## What to expect
+
+- We will acknowledge your report within **5 business days**.
+- We will keep you informed as we confirm the issue and work on a fix.
+- We aim to publish a fix and a GitHub Security Advisory within **90 days** of
+  the initial report. If we need more time, we will tell you why and agree on
+  a new date with you.
+- We will credit you in the advisory unless you ask us not to.
+
+## Supported versions
+
+Security fixes are applied to the `main` branch and to the most recent
+release. Older versions are not maintained.
+
+## Scope
+
+CodeWiki clones or reads repositories that you point it at. In subscription
+mode it routes LLM calls through the local `claude` or `codex` CLI, and in
+IDE-driven mode it runs as an MCP server driven by an AI IDE agent on your
+machine. The trust boundary we care about most is the boundary between the
+analyzed repository and the rest of your system.
+
+In scope:
+
+- Any way for content inside an analyzed repository (source files, READMEs,
+  configuration, file names) to cause CodeWiki or the agent it drives to read
+  or write files outside the intended output directory, execute commands, or
+  exfiltrate data such as API keys
+- Path traversal, command injection, or unsafe deserialization in CodeWiki
+  itself
+- Leakage of credentials, tokens, or environment variables into generated
+  documentation or logs
+- Vulnerabilities in the Docker images or the web viewer shipped in this
+  repository
+
+Out of scope:
+
+- Inaccurate, incomplete, or hallucinated documentation content
+- Vulnerabilities in the underlying LLM providers or agent CLIs (Claude Code,
+  Codex CLI, and others). Please report those upstream.
+- Issues that require the attacker to already control the machine running
+  CodeWiki
+- Findings from automated scanners without a demonstrated impact
+
+If you are unsure whether something is in scope, report it privately anyway
+and we will work it out together.


### PR DESCRIPTION
## Summary

Addresses #104, which pointed out that CodeWiki has no private channel for security reports and no `LICENSE` file despite declaring MIT.

- **`SECURITY.md`**: points reporters at GitHub private vulnerability reporting, commits to acknowledging reports within 5 business days and publishing a fix within 90 days, and states what is in and out of scope for a tool that analyzes untrusted repositories and drives local agent CLIs.
- **`LICENSE`**: the MIT license text that `README.md` and `pyproject.toml` already declare. With this file present GitHub detects the license and the existing README badge link resolves.
